### PR TITLE
Logic difficulty options, variable item flags, WebHost support

### DIFF
--- a/manual_kirbytripledeluxe_seafo/data/categories.json
+++ b/manual_kirbytripledeluxe_seafo/data/categories.json
@@ -92,6 +92,9 @@
         "hidden": true,
         "yaml_option": ["randomize_ability_testing_room"]
     },
+    "Ability Testing Room": {
+        "hidden": true
+    },
     "Goal Games": {
         "hidden": true
     },

--- a/manual_kirbytripledeluxe_seafo/data/items.json
+++ b/manual_kirbytripledeluxe_seafo/data/items.json
@@ -452,7 +452,7 @@
 	{
 		"count":1,
 		"name": "Copy Ability Testing Room",
-		"category": ["Abilities","ATR","Archer Access","Beam Access","Beetle Access","Bell Access","Bomb Access","Circus Access","Crash Access","Cutter Access","Fighter Access","Fire Access","Hammer Access","Ice Access","Leaf Access","Mike Access","Needle Access","Ninja Access","Parasol Access","Spark Access","Spear Access","Stone Access","Sword Access","Wheel Access","Whip Access","Wing Access"],
+		"category": ["Abilities","Ability Testing Room","ATR","Archer Access","Beam Access","Beetle Access","Bell Access","Bomb Access","Circus Access","Crash Access","Cutter Access","Fighter Access","Fire Access","Hammer Access","Ice Access","Leaf Access","Mike Access","Needle Access","Ninja Access","Parasol Access","Spark Access","Spear Access","Stone Access","Sword Access","Wheel Access","Whip Access","Wing Access"],
 		"progression": true
 	},
 	{

--- a/manual_kirbytripledeluxe_seafo/data/locations.json
+++ b/manual_kirbytripledeluxe_seafo/data/locations.json
@@ -4483,7 +4483,7 @@
 		"name": "FiFi Stage 1 - Keychain in Grass",
 		"region": "Fine Fields Stage 1",
 		"category": ["B1 - Fine Fields Stage 1","Keychains"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR (|Cutter| AND |@Cutter Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND |Sword|) OR ({normal_logic()} AND (|Fire| OR |Sword|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR (|Cutter| AND |@Cutter Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "FiFi Stage 1 - Keychain Under Crate",
@@ -4543,13 +4543,13 @@
 		"name": "FiFi Stage 2 - Sun Stone 3 in Tilt Water Pot Room",
 		"region": "Fine Fields Stage 2",
 		"category": ["B2 - Fine Fields Stage 2","Sun Stone Locations"],
-		"requires": []
+		"requires": "({easy_logic()} AND (|Sword| OR |Whip|)) OR {not_easy_logic()}"
 	},
 	{
 		"name": "FiFi Stage 2 - Keychain Above Blade Knight",
 		"region": "Fine Fields Stage 2",
 		"category": ["B2 - Fine Fields Stage 2","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND (|Sword| OR |Whip|)) OR {not_easy_logic()}"
 	},
 	{
 		"name": "FiFi Stage 2 - Rare Keychain Above Goal Door",
@@ -4567,13 +4567,13 @@
 		"name": "FiFi Stage 3 - Rare Keychain Above Sir Kibble",
 		"region": "Fine Fields Stage 3",
 		"category": ["B3 - Fine Fields Stage 3","Keychains"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND (|Cutter| OR |Sword|)) OR ({normal_logic()} AND (|Cutter| OR |Sword| OR |Fire|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "FiFi Stage 3 - Keychain in HAL Room",
 		"region": "Fine Fields Stage 3",
 		"category": ["B3 - Fine Fields Stage 3","Keychains"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND (|Cutter| OR |Sword|)) OR ({normal_logic()} AND (|Cutter| OR |Sword| OR |Fire|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "FiFi Stage 3 - Sun Stone 1 in 3D Tilt Missile Area",
@@ -4585,13 +4585,13 @@
 		"name": "FiFi Stage 3 - Keychain in Boulder Area",
 		"region": "Fine Fields Stage 3",
 		"category": ["B3 - Fine Fields Stage 3","Keychains"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND |Fire|) OR ({normal_logic()} AND (|Cutter| OR |Sword| OR |Fire|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "FiFi Stage 3 - Sun Stone 2 in Fuse Cannon Room",
 		"region": "Fine Fields Stage 3",
 		"category": ["B3 - Fine Fields Stage 3","Sun Stone Locations"],
-		"requires": "(|Circus| AND |@Circus Access:1|) OR (|Fighter| AND (|@Fighter Access:1| OR (|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)"
+		"requires": "({easy_logic()} AND |Fire|) OR ({normal_logic()} AND (|Fire| OR (|Fighter| AND (|Cutter| OR |Sword|)))) OR ({hard_logic()} AND ((|Circus| AND |@Circus Access:1|) OR (|Fighter| AND (|@Fighter Access:1| OR (|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)))"
 	},
 	{
 		"name": "FiFi Stage 3 - Sun Stone 3 in Ball and Chain Room",
@@ -4621,7 +4621,7 @@
 		"name": "FiFi Stage 4 - Keychain Behind Beetley",
 		"region": "Fine Fields Stage 4",
 		"category": ["B4 - Fine Fields Stage 4","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND (|Beetle| OR |Fire|)) OR ({normal_logic()} AND (|Beetle| OR |Cutter| OR |Fire| OR |Sword|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR |Beetle| OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "FiFi Stage 4 - Sun Stone 1 Behind First Key Gate",
@@ -4651,7 +4651,7 @@
 		"name": "FiFi Stage 4 - Keychain Below Blade Knight",
 		"region": "Fine Fields Stage 4",
 		"category": ["B4 - Fine Fields Stage 4","Keychains"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR |Beam| OR |Beetle| OR |Bell| OR (|Bomb| AND |@Bomb Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR |Needle| OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR (|Spear| AND |@Spear Access:1|) OR (|Stone| AND |@Stone Access:1|) OR |Sword| OR (|Wheel| AND |@Wheel Access:1|) OR (|Whip| AND |@Whip Access:1|) OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND (|Beam| OR |Needle| OR |Spark| OR |Sword|)) OR ({normal_logic()} AND (|Beam| OR |Beetle| OR |Bell| OR |Cutter| OR |Fire| OR |Needle| OR |Spark| OR |Sword|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR |Beam| OR |Beetle| OR |Bell| OR (|Bomb| AND |@Bomb Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR |Needle| OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR (|Spear| AND |@Spear Access:1|) OR (|Stone| AND |@Stone Access:1|) OR |Sword| OR (|Wheel| AND |@Wheel Access:1|) OR (|Whip| AND |@Whip Access:1|) OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "FiFi Stage 4 - Sun Stone 3 in Tilt Gondola Area",
@@ -4693,7 +4693,7 @@
 		"name": "FiFi Stage EX - Keychain Below Beetley",
 		"region": "Fine Fields Stage EX",
 		"category": ["B5 - Fine Fields Stage EX","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Beam|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "FiFi Stage EX - Sun Stone",
@@ -4723,7 +4723,7 @@
 		"name": "LoLa Stage 1 - Sun Stone 2 in Wheel Area",
 		"region": "Lollipop Land Stage 1",
 		"category": ["C1 - Lollipop Land Stage 1","Sun Stone Locations"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Bell| AND |@Bell Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND |Spear| AND |@Spear Access:1|))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Parasol| OR (|Stone| AND |@Stone Access:1|) OR (|Sword| AND |@Sword Access:1|) OR |Wheel| OR (|Wing| AND (|@Wing Access:1| OR (|Fine Fields Stage 3| AND |Spear| AND |@Spear Access:1|)))"
+		"requires": "({easy_logic()} AND |Wheel|) OR ({normal_logic()} AND (|Cutter| OR |Fire| OR |Wheel|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR |Beam| OR (|Beetle| AND |@Beetle Access:1|) OR (|Bell| AND |@Bell Access:1|) OR (|Bomb| AND |@Bomb Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Needle| AND |@Needle Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Parasol| OR |Spark| OR (|Spear| AND |@Spear Access:1|) OR (|Stone| AND |@Stone Access:1|) OR (|Sword| AND |@Sword Access:1|) OR |Wheel| OR |Whip| OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "LoLa Stage 1 - Rare Keychain Before Hot Head",
@@ -4759,7 +4759,7 @@
 		"name": "LoLa Stage 2 - Sun Stone 1 in Tilt Rope Weight Room",
 		"region": "Lollipop Land Stage 2",
 		"category": ["C2 - Lollipop Land Stage 2","Sun Stone Locations"],
-		"requires": "|Archer| OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND (|@Leaf Access:1| OR (|Fine Fields Stage 3| AND ((|Circus| AND |@Circus Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|))))) OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR (|Sword| AND |@Sword Access:1|) OR (|Wing| AND (|@Wing Access:1| OR (|Fine Fields Stage 3| AND ((|Circus| AND |@Circus Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|)))))"
+		"requires": "({easy_logic()} AND |Archer| AND |Spear|) OR ({normal_logic()} AND (|Archer| OR |Cutter| OR |Spear|)) OR ({hard_logic()} AND (|Archer| OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND (|@Leaf Access:1| OR (|Fine Fields Stage 3| AND ((|Circus| AND |@Circus Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|))))) OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR (|Sword| AND |@Sword Access:1|) OR (|Wing| AND (|@Wing Access:1| OR (|Fine Fields Stage 3| AND ((|Circus| AND |@Circus Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|)))))))"
 	},
 	{
 		"name": "LoLa Stage 2 - Keychain Below Craby",
@@ -4777,7 +4777,7 @@
 		"name": "LoLa Stage 2 - Rare Keychain Above Rope Platform",
 		"region": "Lollipop Land Stage 2",
 		"category": ["C2 - Lollipop Land Stage 2","Keychains"],
-		"requires": "|Archer| OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Fighter| AND (|@Fighter Access:1| OR (|Circus| AND |@Circus Access:1| AND |Fine Fields Stage 3|))) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR (|Leaf| AND (|@Leaf Access:1| OR (|Circus| AND |@Circus Access:1| AND |Fine Fields Stage 3|))) OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR |Spear| OR (|Stone| AND |@Stone Access:1|) OR (|Sword| AND |@Sword Access:1|) OR (|Wheel| AND (|@Wheel Access:1| OR (|Circus| AND |@Circus Access:1| AND |Fine Fields Stage 3|))) OR (|Wing| AND (|@Wing Access:1| OR (|Circus| AND |@Circus Access:1| AND |Fine Fields Stage 3|)))"
+		"requires": "({easy_logic()} AND |Spear|) OR ({normal_logic()} AND (|Archer| OR |Cutter| OR |Spear|)) OR {hard_logic()}"
 	},
 	{
 		"name": "LoLa Stage 2 - Sun Stone 3 in Toy Trucks Room",
@@ -4831,13 +4831,13 @@
 		"name": "LoLa Stage 3 - Sun Stone 3 Below Searches",
 		"region": "Lollipop Land Stage 3",
 		"category": ["C3 - Lollipop Land Stage 3","Sun Stone Locations"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Whip|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "LoLa Stage 3 - Rare Keychain Above Goal Door",
 		"region": "Lollipop Land Stage 3",
 		"category": ["C3 - Lollipop Land Stage 3","Keychains"],
-		"requires": "|Archer| OR |Beam| OR (|Beetle| AND |@Beetle Access:1|) OR (|Bell| AND |@Bell Access:1|) OR |Bomb| OR (|Circus| AND |@Circus Access:1|) OR (|Cutter| AND |@Cutter Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Ice| OR (|Leaf| AND |@Leaf Access:1|) OR (|Needle| AND |@Needle Access:1|) OR |Ninja| OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR |Spear| OR (|Stone| AND |@Stone Access:1|) OR |Sword| OR (|Wheel| AND |@Wheel Access:1|) OR |Whip| OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND (|Spark| OR |Spear| OR |Sword|)) OR ({normal_logic()} AND (|Archer| OR |Beam| OR |Bomb| OR |Fire| OR |Ice| OR |Ninja| OR |Spark| OR |Spear| OR |Sword| OR |Whip|)) OR ({hard_logic()} AND (|Archer| OR |Beam| OR (|Beetle| AND |@Beetle Access:1|) OR (|Bell| AND |@Bell Access:1|) OR |Bomb| OR (|Circus| AND |@Circus Access:1|) OR (|Cutter| AND |@Cutter Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Ice| OR (|Leaf| AND |@Leaf Access:1|) OR (|Needle| AND |@Needle Access:1|) OR |Ninja| OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR |Spear| OR (|Stone| AND |@Stone Access:1|) OR |Sword| OR (|Wheel| AND |@Wheel Access:1|) OR |Whip| OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "LoLa Stage 3 - Goal Game",
@@ -4903,7 +4903,7 @@
 		"name": "LoLa Stage EX - Keychain Behind Bomb Blocks",
 		"region": "Lollipop Land Stage EX",
 		"category": ["C5 - Lollipop Land Stage EX","Keychains"],
-		"requires": "(|Beetle| AND |@Beetle Access:1|) OR (|Cutter| AND |@Cutter Access:1|) OR |Fighter| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Parasol| OR (|Sword| AND |@Sword Access:1|) OR |Wheel| OR (|Wing| AND (|@Wing Access:1| OR (|Circus| AND |@Circus Access:1| AND |Fine Fields Stage 3|)))"
+		"requires": "({easy_logic()} AND |Wheel|) OR ({normal_logic()} AND (|Fighter| OR |Fire| OR |Parasol| OR |Wheel|)) OR ({hard_logic()} AND ((|Beetle| AND |@Beetle Access:1|) OR (|Cutter| AND |@Cutter Access:1|) OR |Fighter| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Parasol| OR (|Sword| AND |@Sword Access:1|) OR |Wheel| OR (|Wing| AND (|@Wing Access:1| OR (|Circus| AND |@Circus Access:1| AND |Fine Fields Stage 3|)))))"
 	},
 	{
 		"name": "LoLa Stage EX - Rare Keychain Behind Key Gate",
@@ -4915,7 +4915,7 @@
 		"name": "LoLa Stage EX - Keychain in Key Dee Room",
 		"region": "Lollipop Land Stage EX",
 		"category": ["C5 - Lollipop Land Stage EX","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Stone|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "LoLa Stage EX - Sun Stone",
@@ -4945,7 +4945,7 @@
 		"name": "OlOd Stage 1 - Rare Keychain in Pizza Crevice",
 		"region": "Old Odyssey Stage 1",
 		"category": ["D1 - Old Odyssey Stage 1","Keychains"],
-		"requires": "|Archer| OR (|Beam| AND |@Beam Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Bell| OR (|Bomb| AND |@Bomb Access:1|) OR (|Circus| AND |@Circus Access:1|) OR (|Crash| AND |@Crash Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR (|Ice| AND |@Ice Access:1|) OR |Leaf| OR (|Mike| AND |@Mike Access:1|) OR (|Needle| AND |@Needle Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Parasol| OR (|Spark| AND |@Spark Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Stone| OR |Sword| OR (|Wheel| AND |@Wheel Access:1|) OR (|Whip| AND |@Whip Access:1|) OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND |Stone|) OR ({normal_logic()} AND (|Archer| OR |Bell| OR |Cutter| OR |Leaf| OR |Parasol| OR |Stone| OR |Sword|)) OR ({hard_logic()} AND (|Archer| OR (|Beam| AND |@Beam Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Bell| OR (|Bomb| AND |@Bomb Access:1|) OR (|Circus| AND |@Circus Access:1|) OR (|Crash| AND |@Crash Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR (|Ice| AND |@Ice Access:1|) OR |Leaf| OR (|Mike| AND |@Mike Access:1|) OR (|Needle| AND |@Needle Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Parasol| OR (|Spark| AND |@Spark Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Stone| OR |Sword| OR (|Wheel| AND |@Wheel Access:1|) OR (|Whip| AND |@Whip Access:1|) OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "OlOd Stage 1 - Keychain in Hypernova Segment",
@@ -4987,19 +4987,19 @@
 		"name": "OlOd Stage 2 - Sun Stone 1 Behind Key Gate",
 		"region": "Old Odyssey Stage 2",
 		"category": ["D2 - Old Odyssey Stage 2","Sun Stone Locations"],
-		"requires": "|Archer| OR |Beam| OR (|Beetle| AND |@Beetle Access:1|) OR (|Bell| AND |@Bell Access:1|) OR |Bomb| OR (|Circus| AND |@Circus Access:1|) OR (|Crash| AND |@Crash Access:1|) OR |Cutter| OR |Fighter| OR (|Fire| AND |@Fire Access:1|) OR |Hammer| OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR |Mike| OR |Needle| OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR |Spear| OR |Stone| OR (|Sword| AND |@Sword Access:1|) OR (|Wheel| AND |@Wheel Access:1|) OR |Whip| OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND |Spear|) OR ({normal_logic()} AND (|Archer| OR |Beam| OR |Bomb| OR |Cutter| OR |Fighter| OR |Hammer| OR |Mike| OR |Needle| OR |Spark| OR |Spear| OR |Stone| OR |Whip|)) OR ({hard_logic()} AND (|Archer| OR |Beam| OR (|Beetle| AND |@Beetle Access:1|) OR (|Bell| AND |@Bell Access:1|) OR |Bomb| OR (|Circus| AND |@Circus Access:1|) OR (|Crash| AND |@Crash Access:1|) OR |Cutter| OR |Fighter| OR (|Fire| AND |@Fire Access:1|) OR |Hammer| OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR |Mike| OR |Needle| OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR |Spear| OR |Stone| OR (|Sword| AND |@Sword Access:1|) OR (|Wheel| AND |@Wheel Access:1|) OR |Whip| OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "OlOd Stage 2 - Sun Stone 2 in Walky Room",
 		"region": "Old Odyssey Stage 2",
 		"category": ["D2 - Old Odyssey Stage 2","Sun Stone Locations"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Mike| AND (|Beam| OR |Cutter|)) OR {not_easy_logic()}"
 	},
 	{
 		"name": "OlOd Stage 2 - Rare Keychain After Bonkers Fight",
 		"region": "Old Odyssey Stage 2",
 		"category": ["D2 - Old Odyssey Stage 2","Keychains"],
-		"requires": "(|Beetle| AND |@Beetle Access:1|) OR |Hammer| OR |Stone|"
+		"requires": "({easy_logic()} AND |Hammer|) OR ({normal_logic()} AND (|Hammer| OR |Stone|)) OR ({hard_logic()} AND ((|Beetle| AND |@Beetle Access:1|) OR |Hammer| OR |Stone|))"
 	},
 	{
 		"name": "OlOd Stage 2 - Sun Stone 3 in Front of Falling Pillar",
@@ -5041,7 +5041,7 @@
 		"name": "OlOd Stage 3 - Sun Stone 2 Behind Pacto",
 		"region": "Old Odyssey Stage 3",
 		"category": ["D3 - Old Odyssey Stage 3","Sun Stone Locations"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Fire|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "OlOd Stage 3 - Keychain Above Sloped Area",
@@ -5053,7 +5053,7 @@
 		"name": "OlOd Stage 3 - Sun Stone 3 in Fuse Cannon Room",
 		"region": "Old Odyssey Stage 3",
 		"category": ["D3 - Old Odyssey Stage 3","Sun Stone Locations"],
-		"requires": "(|Circus| AND |@Circus Access:1|) OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|))))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)"
+		"requires": "(({easy_logic()} OR {normal_logic()}) AND |Fire|) OR ({hard_logic()} AND ((|Circus| AND |@Circus Access:1|) OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR (|Wing| AND |@Wing Access:1|))))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)))"
 	},
 	{
 		"name": "OlOd Stage 3 - Rare Keychain Before Goal Door",
@@ -5119,7 +5119,7 @@
 		"name": "OlOd Stage 5 - Keychain Under Chilly",
 		"region": "Old Odyssey Stage 5",
 		"category": ["D5 - Old Odyssey Stage 5","Keychains"],
-		"requires": "|Circus| OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR |Sword| OR (|Wing| AND |@Wing Access:1|))))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)"
+		"requires": "({easy_logic()} AND |Circus|) OR ({normal_logic()} AND (|Circus| OR |Fire|)) OR ({hard_logic()} AND (|Circus| OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR |Sword| OR (|Wing| AND |@Wing Access:1|))))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)))"
 	},
 	{
 		"name": "OlOd Stage 5 - Rare Keychain in Fuse Cannon Room",
@@ -5131,13 +5131,13 @@
 		"name": "OlOd Stage 5 - Sun Stone 1 in Ice Block Room",
 		"region": "Old Odyssey Stage 5",
 		"category": ["D5 - Old Odyssey Stage 5","Sun Stone Locations"],
-		"requires": "|Circus| OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR |Sword| OR (|Wing| AND |@Wing Access:1|))))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)"
+		"requires": "({easy_logic()} AND |Fire|) OR ({normal_logic()} AND (|Circus| OR |Fire|)) OR ({hard_logic()} AND (|Circus| OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR |Sword| OR (|Wing| AND |@Wing Access:1|))))) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)))"
 	},
 	{
 		"name": "OlOd Stage 5 - Keychain in Ice Block Room",
 		"region": "Old Odyssey Stage 5",
 		"category": ["D5 - Old Odyssey Stage 5","Keychains"],
-		"requires": "|Circus| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)"
+		"requires": "({easy_logic()} AND |Fire|) OR ({normal_logic()} AND (|Circus| OR |Fire|)) OR ({hard_logic()} AND (|Circus| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)))"
 	},
 	{
 		"name": "OlOd Stage 5 - Sun Stone 2 Behind Key Gate",
@@ -5221,13 +5221,13 @@
 		"name": "WiWo Stage 1 - Keychain Below Destroyable Blocks",
 		"region": "Wild World Stage 1",
 		"category": ["E1 - Wild World Stage 1","Keychains"],
-		"requires": "|Archer| OR |Beam| OR |Beetle| OR (|Bell| AND |@Bell Access:1|) OR |Bomb| OR (|Circus| AND |@Circus Access:1|) OR (|Crash| AND |@Crash Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR (|Ice| AND |@Ice Access:1|) OR |Leaf| OR (|Mike| AND |@Mike Access:1|) OR (|Needle| AND |@Needle Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR (|Spark| AND |@Spark Access:1|) OR |Spear| OR |Stone| OR (|Sword| AND |@Sword Access:1|) OR (|Wheel| AND |@Wheel Access:1|) OR (|Whip| AND |@Whip Access:1|) OR |Wing|"
+		"requires": "({easy_logic()} AND (|Leaf| OR |Spear|)) OR ({normal_logic()} AND (|Archer| OR |Beam| OR |Beetle| OR |Bomb| OR |Cutter| OR |Leaf| OR |Spear| OR |Stone| OR |Wing|)) OR ({hard_logic()} AND (|Archer| OR |Beam| OR |Beetle| OR (|Bell| AND |@Bell Access:1|) OR |Bomb| OR (|Circus| AND |@Circus Access:1|) OR (|Crash| AND |@Crash Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR (|Fire| AND |@Fire Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR (|Ice| AND |@Ice Access:1|) OR |Leaf| OR (|Mike| AND |@Mike Access:1|) OR (|Needle| AND |@Needle Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR (|Spark| AND |@Spark Access:1|) OR |Spear| OR |Stone| OR (|Sword| AND |@Sword Access:1|) OR (|Wheel| AND |@Wheel Access:1|) OR (|Whip| AND |@Whip Access:1|) OR |Wing|))"
 	},
 	{
 		"name": "WiWo Stage 1 - Sun Stone 1 in Tilt Rope Weights Room",
 		"region": "Wild World Stage 1",
 		"category": ["E1 - Wild World Stage 1","Sun Stone Locations"],
-		"requires": "|Archer| OR |Beetle| OR |Cutter| OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR (|Sword| AND |@Sword Access:1|) OR |Wing|"
+		"requires": "({easy_logic()} AND (|Beetle| OR |Leaf| OR |Spear|)) OR ({normal_logic()} AND (|Archer| OR |Beetle| OR |Cutter| OR |Leaf| OR |Spear| OR |Wing|)) OR ({hard_logic()} AND (|Archer| OR |Beetle| OR |Cutter| OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR (|Sword| AND |@Sword Access:1|) OR |Wing|))"
 	},
 	{
 		"name": "WiWo Stage 1 - Keychain Behind Foley",
@@ -5287,7 +5287,7 @@
 		"name": "WiWo Stage 2 - Sun Stone 2 in Wheel Area",
 		"region": "Wild World Stage 2",
 		"category": ["E2 - Wild World Stage 2","Sun Stone Locations"],
-		"requires": "|Wheel|"
+		"requires": "(({easy_logic()} OR {normal_logic()}) AND |Wheel|) OR {hard_logic()}"
 	},
 	{
 		"name": "WiWo Stage 2 - Sun Stone 3 Below Goal Door",
@@ -5329,7 +5329,7 @@
 		"name": "WiWo Stage 3 - Keychain Next to Door",
 		"region": "Wild World Stage 3",
 		"category": ["E3 - Wild World Stage 3","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Ninja|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "WiWo Stage 3 - Rare Keychain Behind Invisible Door",
@@ -5389,13 +5389,13 @@
 		"name": "WiWo Stage 4 - Sun Stone 2 After Blocky Fight",
 		"region": "Wild World Stage 4",
 		"category": ["E4 - Wild World Stage 4","Sun Stone Locations"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR (|Beam| AND |@Beam Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Bell| AND |@Bell Access:1|) OR |Bomb| OR |Circus| OR |Crash| OR |Cutter| OR |Fighter| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Ice| OR |Leaf| OR (|Mike| AND |@Mike Access:1|) OR |Needle| OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR (|Spark| AND |@Spark Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Stone| OR (|Sword| AND |@Sword Access:1|) OR (|Wheel| AND |@Wheel Access:1|) OR (|Whip| AND |@Whip Access:1|) OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND (|Crash| OR |Ice| OR |Needle|)) OR ({normal_logic()} AND (|Bomb| OR |Circus| OR |Crash| OR |Cutter| OR |Fighter| OR |Fire| OR |Ice| OR |Leaf| OR |Needle| OR |Stone|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR (|Beam| AND |@Beam Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Bell| AND |@Bell Access:1|) OR |Bomb| OR |Circus| OR |Crash| OR |Cutter| OR |Fighter| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Ice| OR |Leaf| OR (|Mike| AND |@Mike Access:1|) OR |Needle| OR (|Ninja| AND |@Ninja Access:1|) OR (|Parasol| AND |@Parasol Access:1|) OR (|Spark| AND |@Spark Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Stone| OR (|Sword| AND |@Sword Access:1|) OR (|Wheel| AND |@Wheel Access:1|) OR (|Whip| AND |@Whip Access:1|) OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "WiWo Stage 4 - Keychain Under Stake",
 		"region": "Wild World Stage 4",
 		"category": ["E4 - Wild World Stage 4","Keychains"],
-		"requires": "(|Beetle| AND |@Beetle Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR |Stone|"
+		"requires": "(({easy_logic()} OR {normal_logic()}) AND |Stone|) OR ({hard_logic()} AND ((|Beetle| AND |@Beetle Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR |Stone|))"
 	},
 	{
 		"name": "WiWo Stage 4 - Sun Stone 3 Below Crumbling Blocks",
@@ -5431,13 +5431,13 @@
 		"name": "WiWo Stage 5 - Sun Stone 2 in Grassy Area",
 		"region": "Wild World Stage 5",
 		"category": ["E5 - Wild World Stage 5","Sun Stone Locations"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR (|Sword| AND |@Sword Access:1|) OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND |Fire|) OR ({normal_logic()} AND (|Cutter| OR |Fire| OR |Leaf| OR |Spear|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR (|Sword| AND |@Sword Access:1|) OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "WiWo Stage 5 - Sun Stone 3 in Hidden Scale Room",
 		"region": "Wild World Stage 5",
 		"category": ["E5 - Wild World Stage 5","Sun Stone Locations"],
-		"requires": "(|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR (|Sword| AND |@Sword Access:1|) OR (|Wing| AND |@Wing Access:1|)"
+		"requires": "({easy_logic()} AND |Fire|) OR ({normal_logic()} AND (|Cutter| OR |Fire| OR |Leaf| OR |Spear|)) OR ({hard_logic()} AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR (|Circus| AND |@Circus Access:1|) OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR (|Hammer| AND |@Hammer Access:1|) OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR (|Sword| AND |@Sword Access:1|) OR (|Wing| AND |@Wing Access:1|)))"
 	},
 	{
 		"name": "WiWo Stage 5 - Rare Keychain in 3D Helmet Cannon Area",
@@ -5491,7 +5491,7 @@
 		"name": "WiWo Stage EX - Sun Stone 1 in Fuse Cannon Room",
 		"region": "Wild World Stage EX",
 		"category": ["E6 - Wild World Stage EX","Sun Stone Locations"],
-		"requires": "|Circus| OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR |Wing|)))) OR |Fire| OR |Hammer|"
+		"requires": "({easy_logic()} AND |Circus|) OR ({normal_logic()} AND (|Circus| OR |Fire| OR |Hammer|)) OR ({hard_logic()} AND (|Circus| OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR (|Beetle| AND |@Beetle Access:1|) OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword| OR |Wing|)))) OR |Fire| OR |Hammer|))"
 	},
 	{
 		"name": "WiWo Stage EX - Keychain Behind Tick",
@@ -5515,7 +5515,7 @@
 		"name": "EnEx Stage 1 - Keychain in Flaming Blocks",
 		"region": "Endless Explosions Stage 1",
 		"category": ["F1 - Endless Explosions Stage 1","Keychains"],
-		"requires": "|Ice| OR |Parasol|"
+		"requires": "({easy_logic()} AND |Parasol|) OR ({not_easy_logic()} AND (|Ice| OR |Parasol|))"
 	},
 	{
 		"name": "EnEx Stage 1 - Sun Stone 1 Above Invincibility Candy",
@@ -5527,7 +5527,7 @@
 		"name": "EnEx Stage 1 - Sun Stone 2 in Flaming Blocks Room",
 		"region": "Endless Explosions Stage 1",
 		"category": ["F1 - Endless Explosions Stage 1","Sun Stone Locations"],
-		"requires": "|Ice| OR |Parasol|"
+		"requires": "({easy_logic()} AND |Ice|) OR ({not_easy_logic()} AND (|Ice| OR |Parasol|))"
 	},
 	{
 		"name": "EnEx Stage 1 - Keychain Below Door",
@@ -5539,13 +5539,13 @@
 		"name": "EnEx Stage 1 - Sun Stone 3 Behind Key Door",
 		"region": "Endless Explosions Stage 1",
 		"category": ["F1 - Endless Explosions Stage 1","Sun Stone Locations"],
-		"requires": "(|Beetle| AND |@Beetle Access:1|) OR |Fire| OR |Wheel| OR (|Wing| AND (|@Wing Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR |Circus| OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword|))))"
+		"requires": "({easy_logic()} AND |Wheel|) OR ({normal_logic()} AND (|Fire| OR |Wheel|)) OR ({hard_logic()} AND ((|Beetle| AND |@Beetle Access:1|) OR |Fire| OR |Wheel| OR (|Wing| AND (|@Wing Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR |Circus| OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword|))))))"
 	},
 	{
 		"name": "EnEx Stage 1 - Rare Keychain in Background of First Area",
 		"region": "Endless Explosions Stage 1",
 		"category": ["F1 - Endless Explosions Stage 1","Keychains"],
-		"requires": "(|Beetle| AND |@Beetle Access:1|) OR |Fire| OR |Wheel| OR (|Wing| AND (|@Wing Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR |Circus| OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword|))))"
+		"requires": "({easy_logic()} AND |Wheel|) OR ({normal_logic()} AND (|Fire| OR |Wheel|)) OR ({hard_logic()} AND ((|Beetle| AND |@Beetle Access:1|) OR |Fire| OR |Wheel| OR (|Wing| AND (|@Wing Access:1| OR (|Fine Fields Stage 3| AND ((|Archer| AND |@Archer Access:1|) OR |Circus| OR |Cutter| OR (|Fighter| AND |@Fighter Access:1|) OR (|Hammer| AND |@Hammer Access:1|) OR |Leaf| OR (|Ninja| AND |@Ninja Access:1|) OR (|Spear| AND |@Spear Access:1|) OR |Sword|))))))"
 	},
 	{
 		"name": "EnEx Stage 1 - Goal Game",
@@ -5557,7 +5557,7 @@
 		"name": "EnEx Stage 2 - Rare Keychain Above Flaming Blocks",
 		"region": "Endless Explosions Stage 2",
 		"category": ["F2 - Endless Explosions Stage 2","Keychains"],
-		"requires": "(|Ice| AND |@Ice Access:1|) OR |Ninja| OR (|Parasol| AND |@Parasol Access:1|)"
+		"requires": "(({easy_logic()} OR {normal_logic()}) AND |Ninja|) OR ({hard_logic()} AND ((|Ice| AND |@Ice Access:1|) OR |Ninja| OR (|Parasol| AND |@Parasol Access:1|)))"
 	},
 	{
 		"name": "EnEx Stage 2 - Keychain Behind Scarfy",
@@ -5587,7 +5587,7 @@
 		"name": "EnEx Stage 2 - Sun Stone 2 in Timed Dynamite Room",
 		"region": "Endless Explosions Stage 2",
 		"category": ["F2 - Endless Explosions Stage 2","Sun Stone Locations"],
-		"requires": "(|Hammer| AND |@Hammer Access:1|) OR |Stone|"
+		"requires": "(({easy_logic()} OR {normal_logic()}) AND |Stone|) OR ({hard_logic()} AND ((|Hammer| AND |@Hammer Access:1|) OR |Stone|))"
 	},
 	{
 		"name": "EnEx Stage 2 - Sun Stone 3 in Chest on Boulders",
@@ -5677,19 +5677,19 @@
 		"name": "EnEx Stage 4 - Keychain in Archer Area",
 		"region": "Endless Explosions Stage 4",
 		"category": ["F4 - Endless Explosions Stage 4","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Archer|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "EnEx Stage 4 - Keychain in Second Rotating Wall Area",
 		"region": "Endless Explosions Stage 4",
 		"category": ["F4 - Endless Explosions Stage 4","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Spear|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "EnEx Stage 4 - Rare Keychain in Breakable Wall Block",
 		"region": "Endless Explosions Stage 4",
 		"category": ["F4 - Endless Explosions Stage 4","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Spear|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "EnEx Stage 4 - Sun Stone 3 Between Lava-Falls",
@@ -5713,7 +5713,7 @@
 		"name": "EnEx Stage 5 - Sun Stone 1 After First Miniboss Fight",
 		"region": "Endless Explosions Stage 5",
 		"category": ["F5 - Endless Explosions Stage 5","Sun Stone Locations"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Fire| AND |Wheel|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "EnEx Stage 5 - Keychain Before Second Miniboss Fight",
@@ -5725,13 +5725,13 @@
 		"name": "EnEx Stage 5 - Sun Stone 2 After Second Miniboss Fight",
 		"region": "Endless Explosions Stage 5",
 		"category": ["F5 - Endless Explosions Stage 5","Sun Stone Locations"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Ice| AND |Sword|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "EnEx Stage 5 - Sun Stone 3 After Third Miniboss Fight",
 		"region": "Endless Explosions Stage 5",
 		"category": ["F5 - Endless Explosions Stage 5","Sun Stone Locations"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Beetle| AND |Stone|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "EnEx Stage 5 - Keychain Below Birdon",
@@ -5773,7 +5773,7 @@
 		"name": "EnEx Stage EX - Keychain Below First Door",
 		"region": "Endless Explosions Stage EX",
 		"category": ["F6 - Endless Explosions Stage EX","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND (|Bell| OR |Spear|)) OR {not_easy_logic()}"
 	},
 	{
 		"name": "EnEx Stage EX - Keychain in Bomb Block",
@@ -5833,25 +5833,25 @@
 		"name": "RoRo Stage 1 - Sun Stone 2 in Tilt Rope Weights Room",
 		"region": "Royal Road Stage 1",
 		"category": ["G1 - Royal Road Stage 1","Sun Stone Locations"],
-		"requires": "|Archer| OR |Beetle| OR (|Cutter| AND |@Cutter Access:1|) OR (|Leaf| AND (|@Leaf Access:1| OR (|Fine Fields Stage 3| AND (|Circus| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR |Hammer|)))) OR |Ninja| OR |Spear| OR |Sword| OR |Wing|"
+		"requires": "({easy_logic()} AND |Sword|) OR ({normal_logic()} AND (|Archer| OR |Beetle| OR |Ninja| OR |Spear| OR |Sword| OR |Wing|)) OR ({hard_logic()} AND (|Archer| OR |Beetle| OR (|Cutter| AND |@Cutter Access:1|) OR (|Leaf| AND (|@Leaf Access:1| OR (|Fine Fields Stage 3| AND (|Circus| OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR |Hammer|)))) OR |Ninja| OR |Spear| OR |Sword| OR |Wing|))"
 	},
 	{
 		"name": "RoRo Stage 1 - Keychain in Destroyable Block on Bridge",
 		"region": "Royal Road Stage 1",
 		"category": ["G1 - Royal Road Stage 1","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND (|Fire| OR |Spear|)) OR ({normal_logic()} AND (|Archer| OR |Beetle| OR |Bell| OR |Circus| OR |Fire| OR |Hammer| OR |Ninja| OR |Spark| OR |Spear| OR |Stone| OR |Sword| OR |Wheel| OR |Wing|)) OR {hard_logic()}"
 	},
 	{
 		"name": "RoRo Stage 1 - Sun Stone 3 in Chest After Sectra Tank",
 		"region": "Royal Road Stage 1",
 		"category": ["G1 - Royal Road Stage 1","Sun Stone Locations"],
-		"requires": "|Archer| OR (|Beam| AND |@Beam Access:1|) OR |Beetle| OR |Bell| OR (|Bomb| AND |@Bomb Access:1|) OR |Circus| OR (|Cutter| AND |@Cutter Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR |Hammer| OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Needle| AND |@Needle Access:1|) OR |Ninja| OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR |Spear| OR |Stone| OR |Sword| OR |Wheel| OR (|Whip| AND |@Whip Access:1|) OR |Wing|"
+		"requires": "({easy_logic()} AND (|Fire| OR |Spear|)) OR ({normal_logic()} AND (|Archer| OR |Bell| OR |Circus| OR |Fire| OR |Hammer| OR |Ninja| OR |Spark| OR |Spear| OR |Stone| OR |Sword| OR |Wheel| OR |Wing|)) OR ({hard_logic()} AND (|Archer| OR (|Beam| AND |@Beam Access:1|) OR |Beetle| OR |Bell| OR (|Bomb| AND |@Bomb Access:1|) OR |Circus| OR (|Cutter| AND |@Cutter Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR |Hammer| OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Needle| AND |@Needle Access:1|) OR |Ninja| OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR |Spear| OR |Stone| OR |Sword| OR |Wheel| OR (|Whip| AND |@Whip Access:1|) OR |Wing|))"
 	},
 	{
 		"name": "RoRo Stage 1 - Rare Keychain Below Sectra Tank",
 		"region": "Royal Road Stage 1",
 		"category": ["G1 - Royal Road Stage 1","Keychains"],
-		"requires": "|Archer| OR (|Beam| AND |@Beam Access:1|) OR |Beetle| OR |Bell| OR (|Bomb| AND |@Bomb Access:1|) OR |Circus| OR (|Cutter| AND |@Cutter Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR |Hammer| OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Needle| AND |@Needle Access:1|) OR |Ninja| OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR |Spear| OR |Stone| OR |Sword| OR |Wheel| OR (|Whip| AND |@Whip Access:1|) OR |Wing|"
+		"requires": "({easy_logic()} AND (|Fire| OR |Spear|)) OR ({normal_logic()} AND (|Archer| OR |Bell| OR |Circus| OR |Fire| OR |Hammer| OR |Ninja| OR |Spark| OR |Spear| OR |Stone| OR |Sword| OR |Wheel| OR |Wing|)) OR ({hard_logic()} AND (|Archer| OR (|Beam| AND |@Beam Access:1|) OR |Beetle| OR |Bell| OR (|Bomb| AND |@Bomb Access:1|) OR |Circus| OR (|Cutter| AND |@Cutter Access:1|) OR (|Fighter| AND |@Fighter Access:1|) OR |Fire| OR |Hammer| OR (|Ice| AND |@Ice Access:1|) OR (|Leaf| AND |@Leaf Access:1|) OR (|Needle| AND |@Needle Access:1|) OR |Ninja| OR (|Parasol| AND |@Parasol Access:1|) OR |Spark| OR |Spear| OR |Stone| OR |Sword| OR |Wheel| OR (|Whip| AND |@Whip Access:1|) OR |Wing|))"
 	},
 	{
 		"name": "RoRo Stage 1 - Goal Game",
@@ -5947,7 +5947,7 @@
 		"name": "RoRo Stage 4 - Keychain Near Spectra Spynum",
 		"region": "Royal Road Stage 4",
 		"category": ["G4 - Royal Road Stage 4","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Needle|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "RoRo Stage 4 - Sun Stone",
@@ -5983,7 +5983,7 @@
 		"name": "RoRo Stage 5 - Rare Keychain Below Stake",
 		"region": "Royal Road Stage 5",
 		"category": ["G5 - Royal Road Stage 5","Keychains"],
-		"requires": "|Beetle| OR |Hammer| OR (|Stone| AND |@Stone Access:1|)"
+		"requires": "({easy_logic()} AND |Beetle|) OR ({normal_logic()} AND (|Beetle| OR |Hammer|)) OR ({hard_logic()} AND (|Beetle| OR |Hammer| OR (|Stone| AND |@Stone Access:1|)))"
 	},
 	{
 		"name": "RoRo Stage 5 - Keychain in First 3D Securitron Area",
@@ -5995,7 +5995,7 @@
 		"name": "RoRo Stage 5 - Sun Stone 2 After Fuse Cannon Room",
 		"region": "Royal Road Stage 5",
 		"category": ["G5 - Royal Road Stage 5","Sun Stone Locations"],
-		"requires": "(|Circus| AND |@Circus Access:1|) OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND (|Archer| OR |Beetle| OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR |Sword| OR (|Wing| AND |@Wing Access:1|))))) OR (|Fire| AND |@Fire Access:1|) OR |Hammer|"
+		"requires": "(({easy_logic()} OR {normal_logic()}) AND |Hammer|) OR ({hard_logic()} AND ((|Circus| AND |@Circus Access:1|) OR (|Fighter| AND (|@Fighter Access:1| OR (|Fine Fields Stage 3| AND (|Archer| OR |Beetle| OR |Cutter| OR (|Leaf| AND |@Leaf Access:1|) OR (|Ninja| AND |@Ninja Access:1|) OR |Spear| OR |Sword| OR (|Wing| AND |@Wing Access:1|))))) OR (|Fire| AND |@Fire Access:1|) OR |Hammer|))"
 	},
 	{
 		"name": "RoRo Stage 5 - Keychain in HAL Room",
@@ -6043,13 +6043,13 @@
 		"name": "RoRo Stage EX 1 - Sun Stone 1 in Falling Wall Room",
 		"region": "Royal Road Stage EX 1",
 		"category": ["G6 - Royal Road Stage EX 1","Sun Stone Locations"],
-		"requires": "|Circus| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)"
+		"requires": "({easy_logic()} AND |Circus| AND |Fire|) OR ({normal_logic()} AND (|Circus| OR |Fire|)) OR ({hard_logic()} AND (|Circus| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)))"
 	},
 	{
 		"name": "RoRo Stage EX 1 - Keychain Under Ice Blocks",
 		"region": "Royal Road Stage EX 1",
 		"category": ["G6 - Royal Road Stage EX 1","Keychains"],
-		"requires": "|Circus| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)"
+		"requires": "({easy_logic()} AND |Circus|) OR ({normal_logic()} AND (|Circus| OR |Fire|)) OR ({hard_logic()} AND (|Circus| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)))"
 	},
 	{
 		"name": "RoRo Stage EX 1 - Keychain in Timed Dynamite Area",
@@ -6067,19 +6067,19 @@
 		"name": "RoRo Stage EX 1 - Keychain in 3D Securitron Area",
 		"region": "Royal Road Stage EX 1",
 		"category": ["G6 - Royal Road Stage EX 1","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND |Spark|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "RoRo Stage EX 1 - Rare Keychain in Flaming Blocks",
 		"region": "Royal Road Stage EX 1",
 		"category": ["G6 - Royal Road Stage EX 1","Keychains"],
-	    "requires": "(|Circus| OR |Fighter| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)) AND (|Ice| OR |Parasol|)"
+	    "requires": "({easy_logic()} AND |Fire| AND (|Ice| OR |Parasol|)) OR ({normal_logic()} AND (|Circus| OR |Fighter| OR |Fire|) AND (|Ice| OR |Parasol|)) OR ({hard_logic()} AND ((|Circus| OR |Fighter| OR |Fire| OR (|Hammer| AND |@Hammer Access:1|)) AND (|Ice| OR |Parasol|)))"
 	},
 	{
 		"name": "RoRo Stage EX 1 - Keychain Below Gigatzo",
 		"region": "Royal Road Stage EX 1",
 		"category": ["G6 - Royal Road Stage EX 1","Keychains"],
-		"requires": []
+		"requires": "({easy_logic()} AND (|Fighter| OR |Spear|) OR {not_easy_logic()}"
 	},
 	{
 		"name": "RoRo Stage EX 1 - Sun Stone 3 After Gigant Edge DX Fight",

--- a/manual_kirbytripledeluxe_seafo/data/meta.json
+++ b/manual_kirbytripledeluxe_seafo/data/meta.json
@@ -1,0 +1,40 @@
+{
+    "_comment": [ "remove the _ before a non-comment/info propertie to enable it",
+    "For more info use json schemas to get a description and allowed value for every properties",
+    "https://github.com/ManualForArchipelago/Manual/blob/main/docs/resources/json-schemas-for-world-devs.md"],
+    "docs": {
+        "_comment": [ "For more info on the possible documentation properties check schema and/or the github",
+            "https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md#webworld-class"
+        ],
+        "apworld_description": [
+            "Kirby's back in his first adventure on the Nintendo 3DS system! Use the brand new 3D Warp Stars to travel",
+            "between the foreground and background, and the powerful Hypernova ability to destroy giant obstacles, as",
+            "you explore the hidden land of Floralia on your way to rescue King Dedede from the mysterious Taranza and",
+            "uncover the mystery behind the sudden appearance of the Dreamstalk!"
+        ],
+        "web": {
+            "_comment": "for more info check github https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md#webworld-class",
+            "theme": "grassFlowers",
+            "bug_report_page": "https://discord.gg/T5bcsVHByx",
+            "tutorials": [
+                {
+                    "name": "Multiworld Setup Guide",
+                    "description": "A guide to setting up the Kirby: Triple Deluxe Manual APWorld.",
+                    "language": "English",
+                    "file_name": "setup_en.md",
+                    "link": "setup/en",
+                    "authors": ["Seafo"],
+                    "_comment": "if you don't include the authors it will use creator from game.json"
+                }
+            ],
+            "_options_presets": {
+                "Easy":{
+                    "Option1": true,
+                    "Option2": "potato"
+                }
+            }
+        }
+    },
+    "_comment_":"Enable the generation of puml diagram of your apworld region and locations for debug purposes",
+    "enable_region_diagram": false
+}

--- a/manual_kirbytripledeluxe_seafo/docs/setup_en.md
+++ b/manual_kirbytripledeluxe_seafo/docs/setup_en.md
@@ -1,21 +1,31 @@
-# Manual Randomizer Setup Guide
+# Kirby Triple Deluxe Setup Guide
 
 ## Required Software
 
-- None
+- Kirby: Triple Deluxe for the Nintendo 3DS
+  - Requires a file that has cleared story mode and unlocked all of the EX stages
+- [Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases/latest)
+- [Kirby: Triple Deluxe APWorld](https://github.com/Seatori/ManualAPWorlds/releases)
 
 ## Installation Procedures
 
-Needs content.
+Install Archipelago in accordance to its provided instructions.
+
+Once installed, download the latest Kirby: Triple Deluxe APWorld from the provided link and install it
+into the `custom_worlds` folder.
 
 ## Joining a MultiWorld Game
 
-Needs content.
+Open the Archipelago launcher from your installation, and select Manual Client.
 
-## Multiplayer Manual
+Input the room ID in the top box, and in the next box below it, input `Manual_KirbyTripleDeluxe_Seafo`.
 
-Needs content.
+Click `Connect` in the top right corner. It should prompt you with your name.
+
+Input the name on the room page, which should align with the one you put into your YAML file.
+
+You should now be connected to the server!
 
 ## Game Troubleshooting
 
-Needs content.
+If you need help, please find the Kirby: Triple Deluxe thread in [the Manual Discord server](https://discord.gg/T5bcsVHByx).

--- a/manual_kirbytripledeluxe_seafo/hooks/Options.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Options.py
@@ -1,9 +1,9 @@
 # Object classes from AP that represent different types of options that you can create
-from Options import FreeText, NumericOption, Toggle, DefaultOnToggle, Choice, TextChoice, Range, NamedRange, Visibility
+from Options import (FreeText, NumericOption, Toggle, DefaultOnToggle, Choice, TextChoice, Range, NamedRange,
+                     OptionGroup, Visibility)
 
 # These helper methods allow you to determine if an option has been set, or what its value is, for any player in the multiworld
 from ..Helpers import is_option_enabled, get_option_value
-
 
 
 ####################################################################
@@ -27,11 +27,13 @@ from ..Helpers import is_option_enabled, get_option_value
 #   options["total_characters_to_win_with"] = TotalCharactersToWinWith
 #
 
+
 class RandomizeAbilities(DefaultOnToggle):
     """
-    Prevent use of Kirby's Copy Abilities before obtaining them.
+    Prevent the use of Kirby's Copy Abilities before obtaining them.
     """
     display_name = "Randomize Copy Abilities"
+
 
 class RandomizeKeychains(Choice):
     """
@@ -40,11 +42,13 @@ class RandomizeKeychains(Choice):
     """
     alias_false = 0
     option_no = 0
+    alias_rares_only = 1
     option_only_rares = 1
     alias_true = 2
     option_yes = 2
-    default = 1
+    default = 0
     display_name = "Randomize Keychains"
+
 
 class ExtraStageKeys(DefaultOnToggle):
     """
@@ -53,19 +57,51 @@ class ExtraStageKeys(DefaultOnToggle):
     """
     display_name = "Progressive EX Stage Keys"
 
+
 class KirbyFighters(Toggle):
     """
     Add additional locations for clearing Kirby Fighters with each of the available Copy Abilities.
     """
     display_name = "Add Kirby Fighters Locations"
 
+
 class AbilityTestingRoom(Toggle):
     """
-    Add the ability to access the Copy Ability Testing Room to the item pool. If false, you're never logically considered to have access.
+    Add the ability to access the Copy Ability Testing Room to the item pool.
+    If false, you're never logically considered to have access.
     """
     display_name = "Randomize Ability Testing Room"
 
-class Level1BossRequirement(Range):
+
+class LogicDifficulty(Choice):
+    """
+    Adjusts the expectations for the player's use of abilities.
+
+    Easy only expects the player to use immediately accessible abilities, or if none are available,
+    abilities that were presented to the player shortly before. It has a focus on using the 'intended' methods.
+    Note that even on easy logic, the player is expected to beat all stages and bosses without needing an ability.
+
+    Normal expects the player to use almost any valid ability that can be found in the stage.
+    It also expects the use of some basic tricks that can be done without an ability.
+    Some difficult tricks are still left out of logic.
+
+    Hard expects the player to use almost everything at their disposal.
+    Once the player gains access to an ability through any stage, boss, or the Copy Ability Testing Room,
+    they can be expected to bring that ability to anywhere that it can be used.
+    Damage boosting and using ability stars as projectiles can be also expected.
+    Note that the player is not expected to bring Crash and Mike through mid-boss fights.
+
+    Logic difficulty is only relevant when copy abilities are randomized.
+    """
+    option_easy = 0
+    alias_medium = 1
+    option_normal = 1
+    option_hard = 2
+    default = 1
+    display_name = "Logic Difficulty"
+
+
+class Level1BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 1.
     """
@@ -73,8 +109,13 @@ class Level1BossRequirement(Range):
     range_start = 0
     range_end = 100
     default = 5
-    
-class Level2BossRequirement(Range):
+
+    special_range_names = {
+        "vanilla": 5,
+    }
+
+
+class Level2BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 2.
     """
@@ -82,8 +123,13 @@ class Level2BossRequirement(Range):
     range_start = 0
     range_end = 100
     default = 11
-    
-class Level3BossRequirement(Range):
+
+    special_range_names = {
+        "vanilla": 11,
+    }
+
+
+class Level3BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 3.
     """
@@ -91,8 +137,13 @@ class Level3BossRequirement(Range):
     range_start = 0
     range_end = 100
     default = 18
-    
-class Level4BossRequirement(Range):
+
+    special_range_names = {
+        "vanilla": 18,
+    }
+
+
+class Level4BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 4.
     """
@@ -100,8 +151,13 @@ class Level4BossRequirement(Range):
     range_start = 0
     range_end = 100
     default = 26
-    
-class Level5BossRequirement(Range):
+
+    special_range_names = {
+        "vanilla": 26,
+    }
+
+
+class Level5BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 5.
     """
@@ -109,8 +165,13 @@ class Level5BossRequirement(Range):
     range_start = 0
     range_end = 100
     default = 36
-    
-class Level6BossRequirement(Range):
+
+    special_range_names = {
+        "vanilla": 36,
+    }
+
+
+class Level6BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 6.
     """
@@ -118,16 +179,23 @@ class Level6BossRequirement(Range):
     range_start = 0
     range_end = 100
     default = 43
-    
+
+    special_range_names = {
+        "vanilla": 43,
+    }
+
+
 class QueenSectoniaRequirement(Range):
     """
     How many bosses need to be fought before Queen Sectonia becomes available.
+    Default value is 6.
     """
     display_name = "Bosses Before Queen Sectonia"
     range_start = 1
     range_end = 6
     default = 6
-    
+
+
 class FillerTrapPercent(Range):
     """
     How many random Keychains will be replaced by Lose Ability Traps.
@@ -140,10 +208,12 @@ class FillerTrapPercent(Range):
     range_end = 100
     default = 0
 
+
 class Goal(Range):
     range_start = 0
     range_end = 5
     visibility = Visibility.none
+
 
 # This is called before any manual options are defined, in case you want to define your own with a clean slate or let Manual define over them
 def before_options_defined(options: dict) -> dict:
@@ -152,6 +222,7 @@ def before_options_defined(options: dict) -> dict:
     options["progressive_ex_stage_keys"] = ExtraStageKeys
     options["enable_kirby_fighters_locations"] = KirbyFighters
     options["randomize_ability_testing_room"] = AbilityTestingRoom
+    options["logic_difficulty"] = LogicDifficulty
     options["level_1_boss_sun_stones"] = Level1BossRequirement
     options["level_2_boss_sun_stones"] = Level2BossRequirement
     options["level_3_boss_sun_stones"] = Level3BossRequirement
@@ -160,6 +231,7 @@ def before_options_defined(options: dict) -> dict:
     options["level_6_boss_sun_stones"] = Level6BossRequirement
     options["queen_sectonia_boss_requirement"] = QueenSectoniaRequirement
     return options
+
 
 # This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options
 def after_options_defined(options: dict) -> dict:

--- a/manual_kirbytripledeluxe_seafo/hooks/Rules.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Rules.py
@@ -5,6 +5,36 @@ from BaseClasses import MultiWorld, CollectionState
 
 import re
 
+# Functions used to check the logic difficulty level.
+
+
+def easy_logic(world: World, multiworld: MultiWorld, state: CollectionState, player: int) -> bool:
+    if world.options.logic_difficulty == 0:
+        return True
+    else:
+        return False
+
+
+def normal_logic(world: World, multiworld: MultiWorld, state: CollectionState, player: int) -> bool:
+    if world.options.logic_difficulty == 1:
+        return True
+    else:
+        return False
+
+
+def hard_logic(world: World, multiworld: MultiWorld, state: CollectionState, player: int) -> bool:
+    if world.options.logic_difficulty == 2:
+        return True
+    else:
+        return False
+
+
+def not_easy_logic(world: World, multiworld: MultiWorld, state: CollectionState, player: int) -> bool:
+    if world.options.logic_difficulty > 0:
+        return True
+    else:
+        return False
+
 # Sometimes you have a requirement that is just too messy or repetitive to write out with boolean logic.
 # Define a function here, and you can use it in a requires string with {function_name()}.
 def overfishedAnywhere(world: World, multiworld: MultiWorld, state: CollectionState, player: int):

--- a/manual_kirbytripledeluxe_seafo/hooks/World.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/World.py
@@ -262,6 +262,16 @@ def before_create_item(item_name: str, world: World, multiworld: MultiWorld, pla
 def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, player: int) -> ManualItem:
     if item.name == "Sleep":
         item.classification = ItemClassification.trap
+    if item.name == "Wing":
+        if world.options.logic_difficulty == 0:
+            item.classification = ItemClassification.useful
+    if item.name == "Bomb":
+        if world.options.logic_difficulty == 0 and not world.options.enable_kirby_fighters_locations:
+            item.classification = ItemClassification.useful
+    if item.name == "Copy Ability Testing Room":
+        if world.options.logic_difficulty < 2 or not world.options.randomize_copy_abilities:
+            item.classification = ItemClassification.useful
+
     return item
 
 # This method is run towards the end of pre-generation, before the place_item options have been handled and before AP generation occurs


### PR DESCRIPTION
Adds a choice between easy, normal, and hard logic. Also fixes some errors in the previous logic.
Wing, Bomb, and the Copy Ability Testing Room now change their classifications in accordance to related logic rules.
Wing and Bomb are never needed in easy logic, so they're flagged as useful.
Similarly, the Copy Ability Testing Room isn't needed if logic is set to a value below hard, or if ability shuffling has been disabled.
Added a `meta.json` file and updated `setup_en.md` to provide some basic information, in case people want to use this on their webhosts for some reason.
Also changed the default keychain locations to none, added names for the default boss requirement values, and added a hidden "Ability Testing Room" option group to the "Copy Ability Testing Room" item.