### PR TITLE
KTD: Add option to change how extra Sun Stones work

### DIFF
--- a/manual_kirbytripledeluxe_seafo/hooks/Options.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Options.py
@@ -45,6 +45,7 @@ class RandomizeKeychains(Choice):
     """
     alias_false = 0
     option_no = 0
+    alias_rare_keychains = 1
     alias_rares_only = 1
     option_only_rares = 1
     alias_true = 2
@@ -74,7 +75,7 @@ class KirbyFighters(Toggle):
     Recommended to only enable with Copy Abilities randomized, since otherwise they will all be available immediately.
     Adds 10 checks.
     """
-    display_name = "Add Kirby Fighters Locations"
+    display_name = "Kirby Fighters Locations"
 
 
 class StageRando(Choice):
@@ -168,7 +169,7 @@ class LogicDifficulty(Choice):
 
 class ExtraSunStones(Choice):
     """
-    If some of the Sun Stones aren't needed for any given boss, this determines how the excess will be classified.
+    If some of the Sun Stones aren't needed for any given boss, this determines how the excess will be handled.
 
     'Progression' means that the excess can be placed on priority locations and won't be placed on excluded locations.
     This also determines that the excess are logically expected to be collected.
@@ -179,11 +180,23 @@ class ExtraSunStones(Choice):
     'Filler' means that the excess won't be placed on priority locations but can be placed on excluded locations.
     Just like with 'Useful', they also won't be logically expected to be collected.
     If no Sun Stones are required for any bosses, they will default to this.
+
+    'Removed' means that the excess will be completely removed from the pool and replaced by Keychains.
+    This is similar to 'Filler' but it removes the confusion as to how many Sun Stones you're expected to have.
     """
+    alias_yes = 0
+    alias_keep = 0
+    alias_prog = 0
     option_progression = 0
+    alias_never_exclude = 1
     option_useful = 1
+    alias_normal = 2
+    alias_trash = 2
     option_filler = 2
-    display_name = "Excess Sun Stone Classification"
+    alias_no = 3
+    alias_remove = 3
+    option_removed = 3
+    display_name = "Excess Sun Stones"
 
 
 class Level1BossRequirement(NamedRange):
@@ -345,17 +358,21 @@ class Goal(Range):
     visibility = Visibility.none
 
 
+class DeprecatedFightersName(Toggle):
+    visibility = Visibility.none
+
+
 # This is called before any manual options are defined, in case you want to define your own with a clean slate or let Manual define over them
 def before_options_defined(options: dict) -> dict:
     options["randomize_copy_abilities"] = RandomizeAbilities
     options["keychain_locations"] = RandomizeKeychains
     options["progressive_ex_stage_keys"] = ExtraStageKeys
     options["randomize_ability_testing_room"] = AbilityTestingRoom
-    options["enable_kirby_fighters_locations"] = KirbyFighters
+    options["kirby_fighters_locations"] = KirbyFighters
     options["stage_shuffle"] = StageRando
     options["boss_shuffle"] = BossRando
     options["logic_difficulty"] = LogicDifficulty
-    options["excess_sun_stone_class"] = ExtraSunStones
+    options["excess_sun_stones"] = ExtraSunStones
     options["level_1_boss_sun_stones"] = Level1BossRequirement
     options["level_2_boss_sun_stones"] = Level2BossRequirement
     options["level_3_boss_sun_stones"] = Level3BossRequirement
@@ -363,6 +380,7 @@ def before_options_defined(options: dict) -> dict:
     options["level_5_boss_sun_stones"] = Level5BossRequirement
     options["level_6_boss_sun_stones"] = Level6BossRequirement
     options["queen_sectonia_boss_requirement"] = QueenSectoniaRequirement
+    options["enable_kirby_fighters_locations"] = DeprecatedFightersName
     return options
 
 

--- a/manual_kirbytripledeluxe_seafo/hooks/Options.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Options.py
@@ -117,6 +117,7 @@ class BossRando(Choice):
 
     'Vanilla Dedede' forces the Masked Dedede fight to be placed at the end of Level 6, as is the case normally,
     allowing for vanilla-adjacent seeds that don't require fighting all bosses.
+
     'Early Dedede' forces the Masked Dedede fight to be placed in Level 1.
     This allows for the goal to be placed in a fixed position that doesn't require all Grand Sun Stones,
     permitting the goal requirement to purely be a set amount of Sun Stones without intruding on the other bosses.
@@ -163,6 +164,26 @@ class LogicDifficulty(Choice):
     option_hard = 2
     default = 1
     display_name = "Logic Difficulty"
+
+
+class ExtraSunStones(Choice):
+    """
+    If some of the Sun Stones aren't needed for any given boss, this determines how the excess will be classified.
+
+    'Progression' means that the excess can be placed on priority locations and won't be placed on excluded locations.
+    This also determines that the excess are logically expected to be collected.
+
+    'Useful' means that the excess won't be placed on either priority or excluded locations.
+    They also won't be logically expected to be collected, making it likely that you'll gain access to bosses early.
+
+    'Filler' means that the excess won't be placed on priority locations but can be placed on excluded locations.
+    Just like with 'Useful', they also won't be logically expected to be collected.
+    If no Sun Stones are required for any bosses, they will default to this.
+    """
+    option_progression = 0
+    option_useful = 1
+    option_filler = 2
+    display_name = "Excess Sun Stone Classification"
 
 
 class Level1BossRequirement(NamedRange):
@@ -334,6 +355,7 @@ def before_options_defined(options: dict) -> dict:
     options["stage_shuffle"] = StageRando
     options["boss_shuffle"] = BossRando
     options["logic_difficulty"] = LogicDifficulty
+    options["excess_sun_stone_class"] = ExtraSunStones
     options["level_1_boss_sun_stones"] = Level1BossRequirement
     options["level_2_boss_sun_stones"] = Level2BossRequirement
     options["level_3_boss_sun_stones"] = Level3BossRequirement

--- a/manual_kirbytripledeluxe_seafo/hooks/Options.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Options.py
@@ -358,7 +358,11 @@ class Goal(Range):
     visibility = Visibility.none
 
 
-class DeprecatedFightersName(Toggle):
+class DeprecatedFightersName(Choice):
+    option_false = 0
+    option_true = 1
+    option_disabled = 2
+    default = 2
     visibility = Visibility.none
 
 

--- a/manual_kirbytripledeluxe_seafo/hooks/World.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/World.py
@@ -299,6 +299,19 @@ def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, pl
         if world.options.logic_difficulty < 2 or not world.options.randomize_copy_abilities:
             item.classification = ItemClassification.useful
 
+    prog_sun_stones = max(world.options.level_1_sun_stones, world.options.level_2_sun_stones,
+                          world.options.level_3_sun_stones, world.options.level_4_sun_stones,
+                          world.options.level_5_sun_stones, world.options.level_6_sun_stones)
+    if prog_sun_stones == 0:
+        world.options.excess_sun_stone_class = 2
+        if item.name == "Sun Stone":
+            item.classification = ItemClassification.filler
+        return item
+
+    print(item.name == "Sun Stone")
+    # if world.options.excess_sun_stone_class == 1:
+        # total_sun_stones =
+
     return item
 
 

--- a/manual_kirbytripledeluxe_seafo/hooks/World.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/World.py
@@ -38,7 +38,7 @@ def hook_get_filler_item_name(world: World, multiworld: MultiWorld, player: int)
 
 # Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):
-    if world.options.enable_kirby_fighters_locations:
+    if world.options.enable_kirby_fighters_locations.value < 2:
         raise Exception("Outdated option name 'enable_kirby_fighters_locations' detected. Please use an updated YAML.")
     sectonia_boss_req = get_option_value(multiworld, player, "queen_sectonia_boss_requirement")
     if sectonia_boss_req == -1:

--- a/manual_kirbytripledeluxe_seafo/hooks/World.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/World.py
@@ -38,6 +38,8 @@ def hook_get_filler_item_name(world: World, multiworld: MultiWorld, player: int)
 
 # Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):
+    if world.options.enable_kirby_fighters_locations:
+        raise Exception("Outdated option name 'enable_kirby_fighters_locations' detected. Please use an updated YAML.")
     sectonia_boss_req = get_option_value(multiworld, player, "queen_sectonia_boss_requirement")
     if sectonia_boss_req == -1:
         world.options.goal.value = sectonia_boss_req + 1
@@ -220,9 +222,46 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
         multiworld.push_precollected(first_stage)
         item_pool.remove(first_stage)
     else:
-        raise Exception("Invalid value for option \'Stage Shuffle\'. \nPlease report this to the maintainer.")
+        raise Exception("Invalid value for option 'Stage Shuffle'. Please report this to the maintainer.")
 
-    return item_pool
+    # If we want our excess Sun Stones to be progression items, we don't need to do anything here.
+    if world.options.excess_sun_stones == 0:
+        return item_pool
+
+    # Getting the number of how many Sun Stones need to be progression items.
+    prog_sun_stones = max(world.options.level_1_boss_sun_stones, world.options.level_2_boss_sun_stones,
+                          world.options.level_3_boss_sun_stones, world.options.level_4_boss_sun_stones,
+                          world.options.level_5_boss_sun_stones, world.options.level_6_boss_sun_stones)
+    # Checking how many Sun Stones are in the pool.
+    total_sun_stones = [i for i in item_pool if i.name == "Sun Stone"]
+    # Calculating the number of unnecessary Sun Stones by subtracting the number in the pool by how many are needed.
+    excess_sun_stones = len(total_sun_stones) - prog_sun_stones
+
+    # If we know that our excess Sun Stones are being removed, it doesn't matter how many are needed.
+    # So we do this step before checking if we should end.
+    if world.options.excess_sun_stones == 3:
+        for _, item in zip(range(excess_sun_stones), total_sun_stones):
+            sun_stones = next(i for i in item_pool if i.name == "Sun Stone")
+            item_pool.remove(sun_stones)
+        return item_pool
+
+    # If no Sun Stones are required for any bosses, we always want any that may be in the pool to be filler.
+    # This is handled in a later function, so we can just quit out here.
+    if prog_sun_stones == 0:
+        return item_pool
+
+    # Modifying the unneeded Sun Stones based on which option was chosen.
+    if world.options.excess_sun_stones == 1:
+        for _, item in zip(range(excess_sun_stones), total_sun_stones):
+            item.classification = ItemClassification.useful
+        return item_pool
+    elif world.options.excess_sun_stones == 2:
+        for _, item in zip(range(excess_sun_stones), total_sun_stones):
+            item.classification = ItemClassification.filler
+        return item_pool
+    else:
+        # By this point, all four valid options should have been accounted for, so we throw an error if it went wrong.
+        raise Exception("Invalid value for option 'Excess Sun Stones'. Please report this to the maintainer.")
 
     # Some other useful hook options:
 
@@ -274,7 +313,7 @@ def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, pl
     # Bomb has no specific use when story mode is set to easy logic, but is always needed for Kirby Fighters.
     # Though even when Kirby Fighters locations aren't enabled, Bomb is still nice to have.
     if item.name == "Bomb":
-        if world.options.logic_difficulty == 0 and not world.options.enable_kirby_fighters_locations:
+        if world.options.logic_difficulty == 0 and not world.options.kirby_fighters_locations:
             item.classification = ItemClassification.useful
 
     # Mike has an extra requirement added for easy logic, and all of its important requirements are considered 'hard'.
@@ -299,18 +338,15 @@ def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, pl
         if world.options.logic_difficulty < 2 or not world.options.randomize_copy_abilities:
             item.classification = ItemClassification.useful
 
-    prog_sun_stones = max(world.options.level_1_sun_stones, world.options.level_2_sun_stones,
-                          world.options.level_3_sun_stones, world.options.level_4_sun_stones,
-                          world.options.level_5_sun_stones, world.options.level_6_sun_stones)
-    if prog_sun_stones == 0:
-        world.options.excess_sun_stone_class = 2
+    # If we don't need Sun Stones for any bosses, they don't have any use.
+    required_sun_stones = max(world.options.level_1_boss_sun_stones, world.options.level_2_boss_sun_stones,
+                              world.options.level_3_boss_sun_stones, world.options.level_4_boss_sun_stones,
+                              world.options.level_5_boss_sun_stones, world.options.level_6_boss_sun_stones)
+    if required_sun_stones == 0:
+        if world.options.excess_sun_stones < 2:
+            world.options.excess_sun_stones.value = 2
         if item.name == "Sun Stone":
             item.classification = ItemClassification.filler
-        return item
-
-    print(item.name == "Sun Stone")
-    # if world.options.excess_sun_stone_class == 1:
-        # total_sun_stones =
 
     return item
 


### PR DESCRIPTION
Adds an option to change the behavior of Sun Stones that aren't required for any locations.
The available options are "Progression", which doesn't change anything; "Useful", which changes them to be the classification of its namesake; "Filler", which does the same thing for its respective namesake; and "Removed", which takes them out of the pool entirely.
Additionally, if no Sun Stones are required for any boss, they're all automatically changed to be filler items (though removing them takes priority if applicable).
Finally, the `enable_kirby_fighters_locations` option was renamed to just `kirby_fighters_locations`. The old name now throws an error, instructing users to get a new .yaml.