### PR TITLE
KTD: Added an option to remove the Ability Testing Room entirely

### DIFF
--- a/manual_kirbytripledeluxe_seafo/data/categories.json
+++ b/manual_kirbytripledeluxe_seafo/data/categories.json
@@ -35,8 +35,7 @@
         "hidden": true
     },
     "ATR": {
-        "hidden": true,
-        "yaml_option": ["randomize_ability_testing_room"]
+        "hidden": true
     },
     "Sun Stone Locations": {
         "hidden": true
@@ -180,7 +179,7 @@
         "hidden": true
     },
     "J1 - Clear Kirby Fighters": {
-        "yaml_option": ["enable_kirby_fighters_locations"]
+        "yaml_option": ["kirby_fighters_locations"]
     },
     "Clear Kirby Fighters": {
         "hidden": true

--- a/manual_kirbytripledeluxe_seafo/data/locations.json
+++ b/manual_kirbytripledeluxe_seafo/data/locations.json
@@ -6202,6 +6202,13 @@
 		"requires": "|Whip|"
 	},
 	{
+		"name": "Unlock Copy Ability Testing Room",
+		"region": "Eternal Dreamland",
+		"category": ["I1 - Eternal Dreamland"],
+		"requires": "{can_fight_sectonia()}",
+		"place_item": ["Copy Ability Testing Room"]
+	},
+	{
 		"name": "Defeat Queen Sectonia",
 		"region": "Eternal Dreamland",
 		"victory": true,

--- a/manual_kirbytripledeluxe_seafo/hooks/Options.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Options.py
@@ -53,6 +53,15 @@ class RandomizeKeychains(Choice):
     display_name = "Keychain Locations"
 
 
+class KirbyFighters(Toggle):
+    """
+    Add additional locations for clearing Kirby Fighters with each of the available Copy Abilities.
+    Recommended to only enable with Copy Abilities randomized, since otherwise they will all be available immediately.
+    Adds 10 checks.
+    """
+    display_name = "Kirby Fighters Locations"
+
+
 class ExtraStageKeys(DefaultOnToggle):
     """
     When enabled, the EX Stage Key items in the pool will become progressive.
@@ -61,21 +70,19 @@ class ExtraStageKeys(DefaultOnToggle):
     display_name = "Progressive EX Stage Keys"
 
 
-class AbilityTestingRoom(Toggle):
+class AbilityTestingRoom(Choice):
     """
-    Add the ability to access the Copy Ability Testing Room to the item pool.
-    If unrandomized, you're instead considered to have access once you can fight Queen Sectonia.
+    Determines how the Copy Ability Testing Room will be handled.
+    'Postgame' means that it will be unlocked by defeating Queen Sectonia, as is the case normally.
+    'Randomized' means that the ability to access it will become a shuffled item. An equivalent location is not created.
+    'Disabled' means that the player will never be considered to have access to it at all.
     """
-    display_name = "Randomize Ability Testing Room"
-
-
-class KirbyFighters(Toggle):
-    """
-    Add additional locations for clearing Kirby Fighters with each of the available Copy Abilities.
-    Recommended to only enable with Copy Abilities randomized, since otherwise they will all be available immediately.
-    Adds 10 checks.
-    """
-    display_name = "Kirby Fighters Locations"
+    alias_vanilla = 0
+    option_postgame = 0
+    option_randomized = 1
+    alias_removed = 2
+    option_disabled = 2
+    display_name = "Ability Testing Room Access"
 
 
 class StageRando(Choice):
@@ -370,9 +377,9 @@ class DeprecatedFightersName(Choice):
 def before_options_defined(options: dict) -> dict:
     options["randomize_copy_abilities"] = RandomizeAbilities
     options["keychain_locations"] = RandomizeKeychains
-    options["progressive_ex_stage_keys"] = ExtraStageKeys
-    options["randomize_ability_testing_room"] = AbilityTestingRoom
     options["kirby_fighters_locations"] = KirbyFighters
+    options["progressive_ex_stage_keys"] = ExtraStageKeys
+    options["ability_testing_room"] = AbilityTestingRoom
     options["stage_shuffle"] = StageRando
     options["boss_shuffle"] = BossRando
     options["logic_difficulty"] = LogicDifficulty

--- a/manual_kirbytripledeluxe_seafo/hooks/Rules.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Rules.py
@@ -181,18 +181,15 @@ def vanilla_ex_stages(world: World, multiworld: MultiWorld, state: CollectionSta
 # N/A
 
 
-# With the Copy Ability Testing Room randomized, Sectonia's fight gives the player access to the following abilities:
+# Sectonia's fight gives the player access to the following abilities:
 # Archer, Beetle, Bomb, Fighter, Fire, Ice, Leaf, Spark, Stone, Whip, and Wing.
-# Otherwise, it gives the player access to all of them, being the vanilla unlock condition for the ATR.
+#
+# If the Copy Ability Testing Room requires its vanilla conditions, this is used for that as well.
 def can_fight_sectonia(world: World, multiworld: MultiWorld, state: CollectionState, player: int) -> bool:
     if world.options.queen_sectonia_boss_requirement == -1:
         return state.has("VS Masked Dedede", player)
     else:
         return state.has_group_unique("Bosses", player, world.options.queen_sectonia_boss_requirement.value)
-
-
-def randomized_atr(world: World, multiworld: MultiWorld, state: CollectionState, player: int) -> bool:
-    return world.options.randomize_ability_testing_room
 
 
 def can_use_archer(world: World, multiworld: MultiWorld, state: CollectionState, player: int) -> bool:
@@ -257,9 +254,6 @@ def can_use_beam(world: World, multiworld: MultiWorld, state: CollectionState, p
                      or state.has("Wild World Stage 5", player) or state.has("Endless Explosions Stage 1", player)
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 4", player)
                      or state.has("VS Masked Dedede", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -274,9 +268,6 @@ def can_use_beam(world: World, multiworld: MultiWorld, state: CollectionState, p
                      or state.has("Endless Explosions Stage 1", player)
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 4", player)
                      or state.has("VS Masked Dedede", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -323,9 +314,6 @@ def can_use_bell(world: World, multiworld: MultiWorld, state: CollectionState, p
                      or state.has("Endless Explosions Stage EX", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 4", player) or state.has("VS Masked Dedede", player)
                      or state.has("Royal Road Stage EX 1", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -391,9 +379,6 @@ def can_use_circus(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("VS Masked Dedede", player)
                      or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     elif world.options.stage_shuffle == 1:
@@ -410,9 +395,6 @@ def can_use_circus(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 2", player) or state.has("VS Masked Dedede", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -424,9 +406,6 @@ def can_use_circus(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 2", player) or state.has("VS Masked Dedede", player)
                      or state.has("Royal Road Stage EX 1", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -438,9 +417,6 @@ def can_use_crash(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Old Odyssey Stage EX", player)
                      or state.has("Wild World Stage EX", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     elif world.options.stage_shuffle == 1:
@@ -454,9 +430,6 @@ def can_use_crash(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Wild World Stage 3", player) or state.has("Wild World Stage 4", player)
                      or (state.has("Grand Sun Stone", player, 3) and state.has("Level 4 EX Stage Key", player))
                      or state.has("Royal Road Stage 5", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -465,9 +438,6 @@ def can_use_crash(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Wild World Stage 3", player) or state.has("Wild World Stage 4", player)
                      or state.has("Wild World Stage EX", player) or state.has("Royal Road Stage 5", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -488,9 +458,6 @@ def can_use_cutter(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Endless Explosions Stage 4", player)
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 4", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -507,9 +474,6 @@ def can_use_cutter(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 4", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -612,9 +576,6 @@ def can_use_hammer(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Old Odyssey Stage EX", player)
                      or state.has("Wild World Stage EX", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     elif world.options.stage_shuffle == 1:
@@ -629,9 +590,6 @@ def can_use_hammer(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 4", player) or state.has("Royal Road Stage 5", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -640,9 +598,6 @@ def can_use_hammer(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Wild World Stage EX", player) or state.has("Endless Explosions Stage 5", player)
                      or state.has("Royal Road Stage 1", player) or state.has("Royal Road Stage 4", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -709,9 +664,6 @@ def can_use_mike(world: World, multiworld: MultiWorld, state: CollectionState, p
         return (state.has("Mike", player)
                 and (state.has("Grand Sun Stone", player, 2)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -719,9 +671,6 @@ def can_use_mike(world: World, multiworld: MultiWorld, state: CollectionState, p
                 and (state.has("Old Odyssey Stage 2", player) or state.has("Endless Explosions Stage 3", player)
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 2", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -738,9 +687,6 @@ def can_use_needle(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Endless Explosions Stage 3", player)
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 4", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -751,9 +697,6 @@ def can_use_needle(world: World, multiworld: MultiWorld, state: CollectionState,
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 4", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -766,9 +709,6 @@ def can_use_ninja(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Old Odyssey Stage EX", player)
                      or state.has("Endless Explosions Stage EX", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     elif world.options.stage_shuffle == 1:
@@ -783,9 +723,6 @@ def can_use_ninja(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Wild World Stage 2", player) or state.has("Wild World Stage 3", player)
                      or state.has("Endless Explosions Stage 2", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 4", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -796,9 +733,6 @@ def can_use_ninja(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Endless Explosions Stage 2", player)
                      or state.has("Endless Explosions Stage EX", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 4", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -812,9 +746,6 @@ def can_use_parasol(world: World, multiworld: MultiWorld, state: CollectionState
                      or state.has("Endless Explosions Stage EX", player)
                      or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     elif world.options.stage_shuffle == 1:
@@ -831,9 +762,6 @@ def can_use_parasol(world: World, multiworld: MultiWorld, state: CollectionState
                      or state.has("Endless Explosions Stage 4", player)
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 2", player)
                      or state.has("Royal Road Stage 4", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -847,9 +775,6 @@ def can_use_parasol(world: World, multiworld: MultiWorld, state: CollectionState
                      or state.has("Endless Explosions Stage EX", player) or state.has("Royal Road Stage 2", player)
                      or state.has("Royal Road Stage 4", player) or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -897,9 +822,6 @@ def can_use_spear(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Endless Explosions Stage EX", player)
                      or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     elif world.options.stage_shuffle == 1:
@@ -919,9 +841,6 @@ def can_use_spear(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 2", player) or state.has("Royal Road Stage 4", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -938,9 +857,6 @@ def can_use_spear(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Royal Road Stage 2", player) or state.has("Royal Road Stage 4", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -1013,9 +929,6 @@ def can_use_sword(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Endless Explosions Stage 3", player)
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -1030,9 +943,6 @@ def can_use_sword(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Endless Explosions Stage EX", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 5", player) or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 
@@ -1045,9 +955,6 @@ def can_use_wheel(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Endless Explosions Stage EX", player)
                      or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     elif world.options.stage_shuffle == 1:
@@ -1061,9 +968,6 @@ def can_use_wheel(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Wild World Stage 2", player) or state.has("Endless Explosions Stage 1", player)
                      or state.has("Endless Explosions Stage 5", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 4", player) or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
     else:
@@ -1074,9 +978,6 @@ def can_use_wheel(world: World, multiworld: MultiWorld, state: CollectionState, 
                      or state.has("Endless Explosions Stage EX", player) or state.has("Royal Road Stage 1", player)
                      or state.has("Royal Road Stage 4", player) or state.has("Royal Road Stage EX 1", player)
                      or state.has("Copy Ability Testing Room", player)
-                     or (can_fight_sectonia(world, multiworld, state, player)
-                         and not randomized_atr(world, multiworld, state, player)
-                         )
                      )
                 )
 

--- a/manual_kirbytripledeluxe_seafo/hooks/World.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/World.py
@@ -40,7 +40,8 @@ def hook_get_filler_item_name(world: World, multiworld: MultiWorld, player: int)
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):
     if world.options.enable_kirby_fighters_locations.value < 2:
         raise Exception("Outdated option name 'enable_kirby_fighters_locations' detected. Please use an updated YAML.")
-    sectonia_boss_req = get_option_value(multiworld, player, "queen_sectonia_boss_requirement")
+
+    sectonia_boss_req = world.options.queen_sectonia_boss_requirement.value
     if sectonia_boss_req == -1:
         world.options.goal.value = sectonia_boss_req + 1
     else:
@@ -50,49 +51,49 @@ def before_create_regions(world: World, multiworld: MultiWorld, player: int):
 # Called after regions and locations are created, in case you want to see or modify that information. Victory location is included.
 def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     # Use this hook to remove locations from the world
-    level_1_boss = get_option_value(multiworld, player, "level_1_boss_sun_stones")
+    level_1_boss = world.options.level_1_boss_sun_stones.value
     if level_1_boss > 0: 
         remove_first_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 1 Boss" in loc.name
                              and f"- {level_1_boss} Sun Stone" not in loc.name]
     else:
         remove_first_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 1 Boss -" in loc.name]
 
-    level_2_boss = get_option_value(multiworld, player, "level_2_boss_sun_stones")
+    level_2_boss = world.options.level_2_boss_sun_stones.value
     if level_2_boss > 0: 
         remove_second_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 2 Boss" in loc.name
                               and f"- {level_2_boss} Sun Stone" not in loc.name]
     else:
         remove_second_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 2 Boss -" in loc.name]
 
-    level_3_boss = get_option_value(multiworld, player, "level_3_boss_sun_stones")
+    level_3_boss = world.options.level_3_boss_sun_stones.value
     if level_3_boss > 0: 
         remove_third_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 3 Boss" in loc.name
                              and f"- {level_3_boss} Sun Stone" not in loc.name]
     else:
         remove_third_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 3 Boss -" in loc.name]
 
-    level_4_boss = get_option_value(multiworld, player, "level_4_boss_sun_stones")
+    level_4_boss = world.options.level_4_boss_sun_stones.value
     if level_4_boss > 0: 
         remove_fourth_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 4 Boss" in loc.name
                               and f"- {level_4_boss} Sun Stone" not in loc.name]
     else:
         remove_fourth_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 4 Boss -" in loc.name]
 
-    level_5_boss = get_option_value(multiworld, player, "level_5_boss_sun_stones")
+    level_5_boss = world.options.level_5_boss_sun_stones.value
     if level_5_boss > 0: 
         remove_fifth_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 5 Boss" in loc.name
                              and f"- {level_5_boss} Sun Stone" not in loc.name]
     else:
         remove_fifth_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 5 Boss -" in loc.name]
 
-    level_6_boss = get_option_value(multiworld, player, "level_6_boss_sun_stones")
+    level_6_boss = world.options.level_6_boss_sun_stones.value
     if level_6_boss > 0: 
         remove_sixth_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 6 Boss" in loc.name
                              and f"- {level_6_boss} Sun Stone" not in loc.name]
     else:
         remove_sixth_boss = [loc.name for loc in multiworld.get_locations(player) if "Level 6 Boss -" in loc.name]
 
-    keychains = get_option_value(multiworld, player, "keychain_locations")
+    keychains = world.options.keychain_locations.value
     if keychains == 1:
         remove_keychains = [loc.name for loc in multiworld.get_locations(player) if "- Keychain" in loc.name
                             or "Left Keychain" in loc.name or "Right Keychain" in loc.name]
@@ -101,7 +102,7 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     else:
         remove_keychains = []
 
-    stage_shuffle = get_option_value(multiworld, player, "stage_shuffle")
+    stage_shuffle = world.options.stage_shuffle.value
     # Here we remove every 'Unlock Stage' location, since all stages are in their vanilla positions.
     if stage_shuffle == 0:
         remove_stages = [loc.name for loc in multiworld.get_locations(player)
@@ -119,6 +120,12 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     # Finally, if all stages are shuffled, we don't have to remove their respective unlock locations.
     else:
         remove_stages = []
+
+    if world.options.ability_testing_room.value == 0:
+        remove_atr = []
+    else:
+        remove_atr = [loc.name for loc in multiworld.get_locations(player)
+                      if loc.name == "Unlock Copy Ability Testing Room"]
 
     # Add your code here to calculate which locations to remove
 
@@ -140,6 +147,8 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
                 if location.name in remove_keychains:
                     region.locations.remove(location)
                 if location.name in remove_stages:
+                    region.locations.remove(location)
+                if location.name in remove_atr:
                     region.locations.remove(location)
 
     if hasattr(multiworld, "clear_location_cache"):
@@ -165,14 +174,19 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
         item = next(i for i in item_pool if i.name == itemName)
         item_pool.remove(item)
 
-    keychains = get_option_value(multiworld, player, "keychain_locations")
-    if keychains == 0:
+    if world.options.keychain_locations == 0:
         rare_keychains = [i.name for i in item_pool if " Keychain" in i.name]
         for keychains_to_remove in rare_keychains:
             remove_keychains = next(i for i in item_pool if i.name == keychains_to_remove)
             item_pool.remove(remove_keychains)
 
-    stage_shuffle = get_option_value(multiworld, player, "stage_shuffle")
+    if world.options.ability_testing_room == 2:
+        get_atr = [i.name for i in item_pool if i.name == "Copy Ability Testing Room"]
+        for atr in get_atr:
+            remove_atr = next(i for i in item_pool if i.name == atr)
+            item_pool.remove(remove_atr)
+
+    stage_shuffle = world.options.stage_shuffle
     if stage_shuffle == 0:
         # No stages are shuffled here, so we don't need any stage items.
         stages = [i.name for i in item_pool
@@ -353,12 +367,12 @@ def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, pl
 
 # This method is run towards the end of pre-generation, before the place_item options have been handled and before AP generation occurs
 def before_generate_basic(world: World, multiworld: MultiWorld, player: int) -> list:
-    stage_shuffle = get_option_value(multiworld, player, "stage_shuffle")
-    boss_shuffle = get_option_value(multiworld, player, "boss_shuffle")
+    stage_shuffle = world.options.stage_shuffle
+    boss_shuffle = world.options.boss_shuffle
     # Stage Shuffle 4 and Boss Shuffle 3 are the default behavior, so we don't need to place anything here.
     # Stage Shuffle 0 doesn't need any items placed, so we also check for it.
     if (stage_shuffle == 0 or stage_shuffle == 4) and boss_shuffle == 3:
-        return
+        return []
 
     if stage_shuffle == 1 or stage_shuffle == 3:
         main_stage_locs = [loc for loc in multiworld.get_locations(player)
@@ -390,6 +404,9 @@ def before_generate_basic(world: World, multiworld: MultiWorld, player: int) -> 
             next_ex_stage.place_locked_item(ex_stage)
             multiworld.itempool.remove(ex_stage)
             ex_stage_locs.remove(next_ex_stage)
+
+    if boss_shuffle == 3:
+        return []
 
     if boss_shuffle == 0:
         boss_stage_locs = [loc for loc in multiworld.get_locations(player)


### PR DESCRIPTION
Title.
Also renamed the Ability Testing Room option and its other values, rearranged some options, did some general cleanup (including finally culling `get_option_value`), fixed the Ability Testing Room option requiring a hint to ensure the player can tell which value was chosen if it was randomly decided, and fixed the `kirby_fighters_locations` option not doing anything.