### PR TITLE
KTD: Add Sun Stone Count and Goal Game Locations options

### DIFF
--- a/manual_kirbytripledeluxe_seafo/data/categories.json
+++ b/manual_kirbytripledeluxe_seafo/data/categories.json
@@ -41,7 +41,8 @@
         "hidden": true
     },
     "Goal Games": {
-        "hidden": true
+        "hidden": true,
+        "yaml_option": ["goal_game_locations"]
     },
     "Rare Keychain Locations": {
         "hidden": true

--- a/manual_kirbytripledeluxe_seafo/hooks/Options.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Options.py
@@ -186,9 +186,16 @@ class LogicDifficulty(Choice):
 class SunStoneCount(Range):
     """
     Determines the number of Sun Stones that will be added to the pool of randomized items.
-    If there aren't enough locations for the number defined, Grand Sun Stones, EX Stage Keys, Copy Abilities,
+
+    If there aren't enough locations for the number chosen, then Grand Sun Stones; EX Stage Keys; Copy Abilities;
     and the Copy Ability Testing Room will take priority over Sun Stones.
-    The Sun Stone count also decides the upper limit for boss unlocks, and they'll be lowered it to match if necessary.
+
+    The Sun Stone count also decides the upper limit for boss unlock conditions,
+    and those requirements will be lowered to match this if necessary.
+
+    The value of this option may be modified by other factors, such as a limited number of locations being added.
+    The number in the spoiler log should always match the number of Sun Stones created after it was modified.
+
     Default value is 100.
     """
     range_start = 0
@@ -232,6 +239,7 @@ class ExtraSunStones(Choice):
 class Level1BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 1.
+    Will be lowered to match the number of Sun Stones created if that number is lower than the requirement defined here.
     """
     display_name = "Sun Stones for Level 1 Boss"
     range_start = 0
@@ -251,6 +259,7 @@ class Level1BossRequirement(NamedRange):
 class Level2BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 2.
+    Will be lowered to match the number of Sun Stones created if that number is lower than the requirement defined here.
     """
     display_name = "Sun Stones for Level 2 Boss"
     range_start = 0
@@ -270,6 +279,7 @@ class Level2BossRequirement(NamedRange):
 class Level3BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 3.
+    Will be lowered to match the number of Sun Stones created if that number is lower than the requirement defined here.
     """
     display_name = "Sun Stones for Level 3 Boss"
     range_start = 0
@@ -289,6 +299,7 @@ class Level3BossRequirement(NamedRange):
 class Level4BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 4.
+    Will be lowered to match the number of Sun Stones created if that number is lower than the requirement defined here.
     """
     display_name = "Sun Stones for Level 4 Boss"
     range_start = 0
@@ -308,6 +319,7 @@ class Level4BossRequirement(NamedRange):
 class Level5BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 5.
+    Will be lowered to match the number of Sun Stones created if that number is lower than the requirement defined here.
     """
     display_name = "Sun Stones for Level 5 Boss"
     range_start = 0
@@ -327,6 +339,7 @@ class Level5BossRequirement(NamedRange):
 class Level6BossRequirement(NamedRange):
     """
     How many Sun Stones are required to battle the boss of Level 6.
+    Will be lowered to match the number of Sun Stones created if that number is lower than the requirement defined here.
     """
     display_name = "Sun Stones for Level 6 Boss"
     range_start = 0

--- a/manual_kirbytripledeluxe_seafo/hooks/Options.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Options.py
@@ -53,6 +53,15 @@ class RandomizeKeychains(Choice):
     display_name = "Keychain Locations"
 
 
+class GoalGames(DefaultOnToggle):
+    """
+    Add additional locations for doing each of the Goal Games across the stages.
+    Technically, the location is based on the Keychain that is awarded for winning, but since it has no logical
+    significance, you're free to decide whether it's for the Keychain or just doing the Goal Game by yourself.
+    """
+    display_name = "Goal Game Locations"
+
+
 class KirbyFighters(Toggle):
     """
     Add additional locations for clearing Kirby Fighters with each of the available Copy Abilities.
@@ -172,6 +181,20 @@ class LogicDifficulty(Choice):
     option_hard = 2
     default = 1
     display_name = "Logic Difficulty"
+
+
+class SunStoneCount(Range):
+    """
+    Determines the number of Sun Stones that will be added to the pool of randomized items.
+    If there aren't enough locations for the number defined, Grand Sun Stones, EX Stage Keys, Copy Abilities,
+    and the Copy Ability Testing Room will take priority over Sun Stones.
+    The Sun Stone count also decides the upper limit for boss unlocks, and they'll be lowered it to match if necessary.
+    Default value is 100.
+    """
+    range_start = 0
+    range_end = 100
+    default = 100
+    display_name = "Number of Sun Stones"
 
 
 class ExtraSunStones(Choice):
@@ -377,12 +400,14 @@ class DeprecatedFightersName(Choice):
 def before_options_defined(options: dict) -> dict:
     options["randomize_copy_abilities"] = RandomizeAbilities
     options["keychain_locations"] = RandomizeKeychains
+    options["goal_game_locations"] = GoalGames
     options["kirby_fighters_locations"] = KirbyFighters
     options["progressive_ex_stage_keys"] = ExtraStageKeys
     options["ability_testing_room"] = AbilityTestingRoom
     options["stage_shuffle"] = StageRando
     options["boss_shuffle"] = BossRando
     options["logic_difficulty"] = LogicDifficulty
+    options["sun_stone_count"] = SunStoneCount
     options["excess_sun_stones"] = ExtraSunStones
     options["level_1_boss_sun_stones"] = Level1BossRequirement
     options["level_2_boss_sun_stones"] = Level2BossRequirement

--- a/manual_kirbytripledeluxe_seafo/hooks/World.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/World.py
@@ -1,6 +1,7 @@
 # Object classes from AP core, to represent an entire MultiWorld and this individual World that's part of it
 from worlds.AutoWorld import World
 from BaseClasses import MultiWorld, CollectionState, ItemClassification
+from Options import OptionError
 
 # Object classes from Manual -- extending AP core -- representing items and locations that are used in generation
 from ..Items import ManualItem
@@ -39,13 +40,59 @@ def hook_get_filler_item_name(world: World, multiworld: MultiWorld, player: int)
 # Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.
 def before_create_regions(world: World, multiworld: MultiWorld, player: int):
     if world.options.enable_kirby_fighters_locations.value < 2:
-        raise Exception("Outdated option name 'enable_kirby_fighters_locations' detected. Please use an updated YAML.")
+        raise OptionError("Outdated option name 'enable_kirby_fighters_locations'. Please use an updated YAML.")
 
     sectonia_boss_req = world.options.queen_sectonia_boss_requirement.value
     if sectonia_boss_req == -1:
         world.options.goal.value = sectonia_boss_req + 1
     else:
         world.options.goal.value = sectonia_boss_req
+
+    keychain_locations = world.options.keychain_locations
+
+    if keychain_locations > 0 or world.options.goal_game_locations:
+        pass
+    else:
+        location_total = 106
+        item_total = 11
+        if world.options.randomize_copy_abilities:
+            int(item_total) + 25
+        # if world.options.keychain_locations == 1:
+        #     int(location_total) + 35
+        # if world.options.keychain_locations == 2:
+        #     int(location_total) + 137
+        # if world.options.goal_game_locations:
+        #     int(location_total) + 35
+        if world.options.kirby_fighters_locations:
+            int(location_total) + 10
+        if world.options.ability_testing_room == 1:
+            int(item_total) + 1
+        extra_locations = location_total - item_total
+        if extra_locations > 100:
+            sun_stone_locations = 100
+        else:
+            sun_stone_locations = extra_locations
+        world.options.sun_stone_count.value = sun_stone_locations
+
+    sun_stones = world.options.sun_stone_count.value
+
+    if world.options.level_1_boss_sun_stones > sun_stones:
+        world.options.level_1_boss_sun_stones.value = sun_stones
+
+    if world.options.level_2_boss_sun_stones > sun_stones:
+        world.options.level_2_boss_sun_stones.value = sun_stones
+
+    if world.options.level_3_boss_sun_stones > sun_stones:
+        world.options.level_3_boss_sun_stones.value = sun_stones
+
+    if world.options.level_4_boss_sun_stones > sun_stones:
+        world.options.level_4_boss_sun_stones.value = sun_stones
+
+    if world.options.level_5_boss_sun_stones > sun_stones:
+        world.options.level_5_boss_sun_stones.value = sun_stones
+
+    if world.options.level_6_boss_sun_stones > sun_stones:
+        world.options.level_6_boss_sun_stones.value = sun_stones
 
 
 # Called after regions and locations are created, in case you want to see or modify that information. Victory location is included.
@@ -237,6 +284,12 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
         item_pool.remove(first_stage)
     else:
         raise Exception("Invalid value for option 'Stage Shuffle'. Please report this to the maintainer.")
+
+    if world.options.sun_stone_count < 100:
+        unneeded_sun_stones = 100 - world.options.sun_stone_count.value
+        for _ in range(unneeded_sun_stones):
+            remove_sun_stones = next(i for i in item_pool if i.name == "Sun Stone")
+            item_pool.remove(remove_sun_stones)
 
     # If we want our excess Sun Stones to be progression items, we don't need to do anything here.
     if world.options.excess_sun_stones == 0:


### PR DESCRIPTION
Adds an option to change how many Sun Stones are added to the pool.
Due to the way this option works, it allowed for the number of locations to be more customizable, meaning that an option for toggling Goal Game locations could also be implemented.
As a result, this also adds the aforementioned option for toggling Goal Game locations.