### PR TITLE
KTD: Add extra hint information

### DIFF
--- a/manual_kirbytripledeluxe_seafo/data/locations.json
+++ b/manual_kirbytripledeluxe_seafo/data/locations.json
@@ -3,4481 +3,3841 @@
 		"name": "Level 1 - Unlock 2nd Stage",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 1 - Unlock 3rd Stage",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 1 - Unlock 4th Stage",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 1 Boss",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": [],
-		"place_item_category": ["Bosses"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 1 Boss - 1 Sun Stone",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:1|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:1|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 2 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:2|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:2|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 3 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:3|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:3|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 4 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:4|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:4|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 5 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:5|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:5|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 6 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:6|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:6|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 7 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:7|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:7|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 8 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:8|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:8|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 9 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:9|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:9|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 10 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:10|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:10|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 11 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:11|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:11|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 12 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:12|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:12|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 13 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:13|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:13|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 14 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:14|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:14|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 15 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:15|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:15|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 16 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:16|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:16|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 17 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:17|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:17|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 18 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:18|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:18|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 19 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:19|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:19|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 20 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:20|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:20|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 21 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:21|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:21|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 22 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:22|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:22|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 23 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:23|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:23|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 24 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:24|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:24|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 25 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:25|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:25|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 26 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:26|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:26|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 27 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:27|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:27|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 28 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:28|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:28|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 29 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:29|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:29|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 30 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:30|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:30|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 31 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:31|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:31|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 32 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:32|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:32|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 33 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:33|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:33|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 34 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:34|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:34|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 35 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:35|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:35|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 36 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:36|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:36|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 37 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:37|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:37|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 38 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:38|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:38|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 39 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:39|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:39|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 40 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:40|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:40|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 41 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:41|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:41|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 42 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:42|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:42|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 43 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:43|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:43|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 44 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:44|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:44|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 45 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:45|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:45|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 46 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:46|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:46|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 47 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:47|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:47|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 48 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:48|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:48|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 49 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:49|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:49|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 50 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:50|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:50|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 51 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:51|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:51|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 52 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:52|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:52|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 53 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:53|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:53|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 54 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:54|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:54|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 55 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:55|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:55|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 56 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:56|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:56|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 57 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:57|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:57|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 58 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:58|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:58|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 59 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:59|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:59|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 60 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:60|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:60|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 61 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:61|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:61|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 62 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:62|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:62|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 63 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:63|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:63|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 64 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:64|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:64|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 65 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:65|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:65|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 66 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:66|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:66|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 67 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:67|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:67|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 68 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:68|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:68|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 69 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:69|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:69|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 70 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:70|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:70|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 71 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:71|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:71|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 72 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:72|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:72|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 73 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:73|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:73|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 74 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:74|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:74|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 75 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:75|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:75|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 76 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:76|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:76|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 77 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:77|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:77|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 78 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:78|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:78|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 79 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:79|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:79|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 80 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:80|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:80|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 81 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:81|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:81|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 82 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:82|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:82|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 83 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:83|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:83|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 84 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:84|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:84|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 85 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:85|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:85|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 86 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:86|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:86|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 87 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:87|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:87|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 88 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:88|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:88|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 89 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:89|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:89|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 90 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:90|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:90|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 91 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:91|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:91|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 92 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:92|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:92|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 93 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:93|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:93|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 94 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:94|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:94|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 95 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:95|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:95|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 96 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:96|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:96|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 97 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:97|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:97|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 98 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:98|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:98|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 99 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:99|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:99|)"
 	},
 	{
 		"name": "Unlock Level 1 Boss - 100 Sun Stones",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages"],
-		"requires": "(|Sun Stone:100|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:100|)"
 	},
 	{
 		"name": "Level 1 - Unlock EX Stage",
 		"region": "Fine Fields",
 		"category": ["A1 - Level 1 Stages","EX Stages"],
-		"requires": "|Progressive EX Stage Key:1| OR |Level 1 EX Stage Key|",
-		"place_item_category": ["Stages"]
+		"requires": "|Progressive EX Stage Key:1| OR |Level 1 EX Stage Key|"
 	},
 	{
 		"name": "Level 2 - Unlock 1st Stage",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 2 - Unlock 2nd Stage",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 2 - Unlock 3rd Stage",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 2 - Unlock 4th Stage",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 2 Boss",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": [],
-		"place_item_category": ["Bosses"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 2 Boss - 1 Sun Stone",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:1|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:1|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 2 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:2|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:2|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 3 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:3|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:3|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 4 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:4|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:4|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 5 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:5|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:5|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 6 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:6|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:6|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 7 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:7|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:7|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 8 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:8|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:8|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 9 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:9|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:9|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 10 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:10|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:10|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 11 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:11|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:11|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 12 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:12|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:12|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 13 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:13|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:13|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 14 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:14|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:14|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 15 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:15|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:15|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 16 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:16|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:16|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 17 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:17|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:17|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 18 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:18|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:18|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 19 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:19|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:19|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 20 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:20|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:20|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 21 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:21|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:21|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 22 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:22|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:22|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 23 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:23|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:23|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 24 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:24|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:24|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 25 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:25|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:25|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 26 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:26|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:26|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 27 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:27|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:27|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 28 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:28|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:28|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 29 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:29|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:29|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 30 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:30|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:30|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 31 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:31|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:31|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 32 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:32|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:32|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 33 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:33|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:33|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 34 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:34|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:34|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 35 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:35|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:35|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 36 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:36|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:36|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 37 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:37|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:37|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 38 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:38|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:38|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 39 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:39|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:39|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 40 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:40|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:40|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 41 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:41|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:41|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 42 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:42|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:42|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 43 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:43|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:43|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 44 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:44|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:44|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 45 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:45|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:45|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 46 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:46|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:46|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 47 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:47|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:47|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 48 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:48|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:48|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 49 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:49|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:49|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 50 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:50|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:50|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 51 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:51|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:51|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 52 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:52|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:52|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 53 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:53|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:53|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 54 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:54|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:54|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 55 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:55|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:55|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 56 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:56|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:56|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 57 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:57|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:57|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 58 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:58|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:58|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 59 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:59|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:59|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 60 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:60|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:60|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 61 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:61|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:61|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 62 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:62|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:62|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 63 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:63|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:63|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 64 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:64|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:64|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 65 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:65|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:65|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 66 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:66|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:66|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 67 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:67|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:67|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 68 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:68|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:68|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 69 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:69|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:69|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 70 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:70|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:70|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 71 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:71|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:71|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 72 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:72|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:72|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 73 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:73|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:73|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 74 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:74|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:74|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 75 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:75|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:75|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 76 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:76|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:76|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 77 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:77|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:77|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 78 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:78|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:78|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 79 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:79|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:79|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 80 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:80|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:80|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 81 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:81|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:81|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 82 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:82|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:82|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 83 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:83|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:83|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 84 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:84|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:84|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 85 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:85|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:85|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 86 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:86|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:86|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 87 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:87|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:87|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 88 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:88|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:88|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 89 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:89|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:89|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 90 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:90|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:90|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 91 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:91|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:91|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 92 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:92|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:92|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 93 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:93|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:93|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 94 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:94|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:94|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 95 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:95|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:95|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 96 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:96|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:96|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 97 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:97|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:97|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 98 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:98|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:98|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 99 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:99|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:99|)"
 	},
 	{
 		"name": "Unlock Level 2 Boss - 100 Sun Stones",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages"],
-		"requires": "(|Sun Stone:100|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:100|)"
 	},
 	{
 		"name": "Level 2 - Unlock EX Stage",
 		"region": "Lollipop Land",
 		"category": ["A2 - Level 2 Stages","EX Stages"],
-		"requires": "|Progressive EX Stage Key:2| OR |Level 2 EX Stage Key|",
-		"place_item_category": ["Stages"]
+		"requires": "|Progressive EX Stage Key:2| OR |Level 2 EX Stage Key|"
 	},
 	{
 		"name": "Level 3 - Unlock 1st Stage",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 3 - Unlock 2nd Stage",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 3 - Unlock 3rd Stage",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 3 - Unlock 4th Stage",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 3 - Unlock 5th Stage",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 3 Boss",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": [],
-		"place_item_category": ["Bosses"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 3 Boss - 1 Sun Stone",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:1|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:1|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 2 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:2|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:2|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 3 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:3|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:3|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 4 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:4|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:4|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 5 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:5|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:5|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 6 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:6|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:6|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 7 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:7|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:7|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 8 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:8|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:8|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 9 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:9|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:9|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 10 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:10|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:10|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 11 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:11|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:11|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 12 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:12|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:12|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 13 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:13|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:13|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 14 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:14|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:14|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 15 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:15|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:15|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 16 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:16|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:16|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 17 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:17|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:17|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 18 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:18|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:18|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 19 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:19|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:19|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 20 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:20|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:20|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 21 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:21|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:21|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 22 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:22|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:22|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 23 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:23|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:23|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 24 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:24|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:24|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 25 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:25|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:25|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 26 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:26|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:26|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 27 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:27|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:27|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 28 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:28|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:28|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 29 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:29|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:29|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 30 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:30|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:30|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 31 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:31|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:31|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 32 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:32|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:32|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 33 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:33|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:33|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 34 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:34|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:34|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 35 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:35|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:35|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 36 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:36|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:36|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 37 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:37|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:37|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 38 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:38|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:38|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 39 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:39|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:39|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 40 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:40|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:40|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 41 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:41|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:41|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 42 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:42|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:42|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 43 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:43|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:43|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 44 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:44|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:44|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 45 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:45|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:45|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 46 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:46|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:46|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 47 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:47|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:47|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 48 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:48|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:48|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 49 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:49|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:49|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 50 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:50|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:50|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 51 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:51|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:51|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 52 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:52|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:52|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 53 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:53|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:53|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 54 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:54|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:54|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 55 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:55|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:55|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 56 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:56|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:56|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 57 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:57|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:57|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 58 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:58|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:58|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 59 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:59|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:59|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 60 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:60|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:60|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 61 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:61|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:61|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 62 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:62|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:62|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 63 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:63|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:63|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 64 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:64|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:64|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 65 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:65|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:65|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 66 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:66|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:66|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 67 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:67|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:67|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 68 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:68|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:68|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 69 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:69|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:69|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 70 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:70|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:70|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 71 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:71|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:71|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 72 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:72|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:72|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 73 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:73|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:73|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 74 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:74|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:74|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 75 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:75|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:75|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 76 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:76|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:76|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 77 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:77|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:77|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 78 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:78|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:78|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 79 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:79|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:79|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 80 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:80|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:80|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 81 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:81|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:81|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 82 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:82|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:82|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 83 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:83|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:83|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 84 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:84|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:84|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 85 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:85|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:85|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 86 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:86|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:86|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 87 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:87|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:87|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 88 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:88|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:88|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 89 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:89|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:89|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 90 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:90|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:90|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 91 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:91|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:91|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 92 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:92|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:92|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 93 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:93|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:93|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 94 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:94|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:94|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 95 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:95|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:95|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 96 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:96|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:96|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 97 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:97|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:97|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 98 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:98|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:98|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 99 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:99|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:99|)"
 	},
 	{
 		"name": "Unlock Level 3 Boss - 100 Sun Stones",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages"],
-		"requires": "(|Sun Stone:100|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:100|)"
 	},
 	{
 		"name": "Level 3 - Unlock EX Stage",
 		"region": "Old Odyssey",
 		"category": ["A3 - Level 3 Stages","EX Stages"],
-		"requires": "|Progressive EX Stage Key:3| OR |Level 3 EX Stage Key|",
-		"place_item_category": ["Stages"]
+		"requires": "|Progressive EX Stage Key:3| OR |Level 3 EX Stage Key|"
 	},
 	{
 		"name": "Level 4 - Unlock 1st Stage",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 4 - Unlock 2nd Stage",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 4 - Unlock 3rd Stage",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 4 - Unlock 4th Stage",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 4 - Unlock 5th Stage",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 4 Boss",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": [],
-		"place_item_category": ["Bosses"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 4 Boss - 1 Sun Stone",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:1|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:1|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 2 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:2|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:2|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 3 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:3|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:3|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 4 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:4|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:4|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 5 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:5|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:5|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 6 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:6|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:6|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 7 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:7|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:7|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 8 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:8|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:8|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 9 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:9|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:9|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 10 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:10|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:10|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 11 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:11|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:11|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 12 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:12|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:12|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 13 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:13|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:13|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 14 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:14|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:14|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 15 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:15|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:15|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 16 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:16|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:16|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 17 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:17|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:17|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 18 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:18|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:18|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 19 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:19|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:19|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 20 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:20|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:20|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 21 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:21|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:21|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 22 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:22|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:22|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 23 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:23|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:23|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 24 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:24|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:24|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 25 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:25|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:25|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 26 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:26|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:26|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 27 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:27|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:27|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 28 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:28|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:28|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 29 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:29|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:29|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 30 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:30|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:30|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 31 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:31|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:31|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 32 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:32|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:32|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 33 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:33|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:33|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 34 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:34|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:34|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 35 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:35|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:35|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 36 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:36|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:36|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 37 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:37|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:37|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 38 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:38|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:38|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 39 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:39|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:39|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 40 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:40|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:40|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 41 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:41|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:41|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 42 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:42|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:42|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 43 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:43|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:43|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 44 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:44|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:44|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 45 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:45|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:45|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 46 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:46|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:46|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 47 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:47|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:47|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 48 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:48|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:48|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 49 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:49|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:49|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 50 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:50|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:50|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 51 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:51|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:51|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 52 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:52|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:52|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 53 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:53|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:53|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 54 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:54|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:54|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 55 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:55|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:55|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 56 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:56|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:56|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 57 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:57|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:57|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 58 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:58|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:58|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 59 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:59|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:59|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 60 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:60|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:60|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 61 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:61|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:61|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 62 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:62|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:62|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 63 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:63|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:63|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 64 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:64|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:64|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 65 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:65|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:65|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 66 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:66|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:66|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 67 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:67|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:67|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 68 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:68|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:68|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 69 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:69|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:69|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 70 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:70|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:70|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 71 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:71|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:71|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 72 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:72|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:72|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 73 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:73|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:73|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 74 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:74|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:74|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 75 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:75|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:75|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 76 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:76|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:76|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 77 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:77|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:77|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 78 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:78|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:78|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 79 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:79|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:79|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 80 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:80|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:80|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 81 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:81|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:81|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 82 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:82|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:82|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 83 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:83|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:83|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 84 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:84|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:84|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 85 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:85|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:85|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 86 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:86|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:86|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 87 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:87|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:87|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 88 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:88|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:88|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 89 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:89|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:89|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 90 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:90|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:90|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 91 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:91|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:91|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 92 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:92|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:92|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 93 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:93|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:93|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 94 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:94|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:94|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 95 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:95|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:95|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 96 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:96|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:96|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 97 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:97|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:97|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 98 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:98|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:98|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 99 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:99|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:99|)"
 	},
 	{
 		"name": "Unlock Level 4 Boss - 100 Sun Stones",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages"],
-		"requires": "(|Sun Stone:100|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:100|)"
 	},
 	{
 		"name": "Level 4 - Unlock EX Stage",
 		"region": "Wild World",
 		"category": ["A4 - Level 4 Stages","EX Stages"],
-		"requires": "|Progressive EX Stage Key:4| OR |Level 4 EX Stage Key|",
-		"place_item_category": ["Stages"]
+		"requires": "|Progressive EX Stage Key:4| OR |Level 4 EX Stage Key|"
 	},
 	{
 		"name": "Level 5 - Unlock 1st Stage",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 5 - Unlock 2nd Stage",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 5 - Unlock 3rd Stage",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 5 - Unlock 4th Stage",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 5 - Unlock 5th Stage",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 5 Boss",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": [],
-		"place_item_category": ["Bosses"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 5 Boss - 1 Sun Stone",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:1|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:1|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 2 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:2|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:2|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 3 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:3|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:3|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 4 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:4|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:4|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 5 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:5|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:5|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 6 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:6|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:6|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 7 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:7|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:7|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 8 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:8|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:8|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 9 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:9|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:9|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 10 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:10|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:10|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 11 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:11|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:11|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 12 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:12|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:12|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 13 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:13|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:13|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 14 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:14|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:14|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 15 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:15|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:15|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 16 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:16|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:16|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 17 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:17|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:17|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 18 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:18|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:18|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 19 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:19|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:19|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 20 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:20|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:20|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 21 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:21|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:21|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 22 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:22|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:22|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 23 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:23|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:23|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 24 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:24|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:24|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 25 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:25|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:25|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 26 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:26|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:26|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 27 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:27|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:27|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 28 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:28|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:28|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 29 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:29|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:29|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 30 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:30|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:30|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 31 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:31|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:31|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 32 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:32|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:32|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 33 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:33|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:33|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 34 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:34|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:34|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 35 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:35|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:35|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 36 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:36|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:36|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 37 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:37|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:37|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 38 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:38|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:38|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 39 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:39|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:39|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 40 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:40|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:40|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 41 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:41|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:41|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 42 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:42|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:42|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 43 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:43|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:43|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 44 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:44|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:44|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 45 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:45|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:45|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 46 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:46|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:46|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 47 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:47|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:47|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 48 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:48|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:48|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 49 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:49|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:49|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 50 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:50|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:50|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 51 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:51|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:51|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 52 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:52|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:52|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 53 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:53|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:53|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 54 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:54|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:54|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 55 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:55|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:55|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 56 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:56|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:56|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 57 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:57|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:57|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 58 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:58|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:58|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 59 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:59|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:59|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 60 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:60|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:60|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 61 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:61|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:61|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 62 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:62|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:62|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 63 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:63|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:63|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 64 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:64|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:64|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 65 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:65|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:65|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 66 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:66|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:66|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 67 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:67|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:67|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 68 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:68|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:68|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 69 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:69|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:69|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 70 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:70|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:70|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 71 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:71|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:71|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 72 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:72|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:72|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 73 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:73|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:73|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 74 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:74|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:74|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 75 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:75|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:75|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 76 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:76|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:76|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 77 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:77|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:77|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 78 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:78|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:78|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 79 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:79|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:79|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 80 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:80|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:80|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 81 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:81|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:81|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 82 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:82|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:82|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 83 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:83|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:83|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 84 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:84|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:84|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 85 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:85|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:85|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 86 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:86|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:86|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 87 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:87|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:87|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 88 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:88|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:88|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 89 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:89|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:89|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 90 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:90|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:90|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 91 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:91|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:91|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 92 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:92|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:92|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 93 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:93|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:93|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 94 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:94|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:94|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 95 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:95|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:95|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 96 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:96|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:96|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 97 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:97|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:97|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 98 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:98|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:98|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 99 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:99|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:99|)"
 	},
 	{
 		"name": "Unlock Level 5 Boss - 100 Sun Stones",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages"],
-		"requires": "(|Sun Stone:100|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:100|)"
 	},
 	{
 		"name": "Level 5 - Unlock EX Stage",
 		"region": "Endless Explosions",
 		"category": ["A5 - Level 5 Stages","EX Stages"],
-		"requires": "|Progressive EX Stage Key:5| OR |Level 5 EX Stage Key|",
-		"place_item_category": ["Stages"]
+		"requires": "|Progressive EX Stage Key:5| OR |Level 5 EX Stage Key|"
 	},
 	{
 		"name": "Level 6 - Unlock 1st Stage",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 6 - Unlock 2nd Stage",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 6 - Unlock 3rd Stage",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 6 - Unlock 4th Stage",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Level 6 - Unlock 5th Stage",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages","Main Stages"],
-		"requires": [],
-		"place_item_category": ["Stages"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 6 Boss",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": [],
-		"place_item_category": ["Bosses"]
+		"requires": []
 	},
 	{
 		"name": "Unlock Level 6 Boss - 1 Sun Stone",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:1|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:1|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 2 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:2|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:2|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 3 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:3|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:3|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 4 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:4|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:4|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 5 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:5|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:5|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 6 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:6|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:6|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 7 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:7|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:7|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 8 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:8|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:8|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 9 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:9|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:9|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 10 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:10|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:10|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 11 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:11|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:11|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 12 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:12|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:12|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 13 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:13|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:13|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 14 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:14|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:14|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 15 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:15|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:15|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 16 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:16|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:16|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 17 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:17|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:17|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 18 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:18|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:18|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 19 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:19|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:19|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 20 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:20|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:20|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 21 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:21|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:21|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 22 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:22|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:22|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 23 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:23|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:23|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 24 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:24|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:24|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 25 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:25|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:25|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 26 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:26|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:26|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 27 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:27|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:27|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 28 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:28|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:28|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 29 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:29|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:29|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 30 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:30|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:30|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 31 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:31|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:31|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 32 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:32|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:32|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 33 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:33|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:33|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 34 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:34|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:34|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 35 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:35|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:35|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 36 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:36|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:36|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 37 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:37|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:37|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 38 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:38|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:38|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 39 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:39|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:39|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 40 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:40|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:40|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 41 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:41|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:41|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 42 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:42|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:42|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 43 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:43|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:43|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 44 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:44|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:44|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 45 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:45|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:45|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 46 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:46|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:46|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 47 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:47|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:47|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 48 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:48|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:48|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 49 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:49|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:49|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 50 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:50|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:50|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 51 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:51|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:51|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 52 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:52|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:52|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 53 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:53|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:53|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 54 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:54|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:54|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 55 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:55|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:55|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 56 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:56|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:56|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 57 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:57|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:57|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 58 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:58|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:58|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 59 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:59|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:59|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 60 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:60|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:60|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 61 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:61|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:61|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 62 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:62|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:62|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 63 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:63|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:63|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 64 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:64|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:64|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 65 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:65|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:65|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 66 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:66|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:66|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 67 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:67|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:67|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 68 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:68|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:68|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 69 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:69|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:69|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 70 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:70|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:70|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 71 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:71|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:71|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 72 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:72|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:72|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 73 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:73|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:73|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 74 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:74|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:74|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 75 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:75|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:75|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 76 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:76|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:76|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 77 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:77|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:77|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 78 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:78|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:78|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 79 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:79|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:79|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 80 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:80|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:80|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 81 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:81|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:81|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 82 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:82|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:82|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 83 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:83|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:83|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 84 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:84|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:84|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 85 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:85|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:85|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 86 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:86|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:86|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 87 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:87|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:87|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 88 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:88|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:88|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 89 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:89|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:89|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 90 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:90|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:90|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 91 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:91|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:91|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 92 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:92|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:92|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 93 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:93|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:93|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 94 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:94|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:94|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 95 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:95|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:95|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 96 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:96|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:96|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 97 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:97|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:97|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 98 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:98|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:98|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 99 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:99|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:99|)"
 	},
 	{
 		"name": "Unlock Level 6 Boss - 100 Sun Stones",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages"],
-		"requires": "(|Sun Stone:100|)",
-		"place_item_category": ["Bosses"]
+		"requires": "(|Sun Stone:100|)"
 	},
 	{
 		"name": "Level 6 - Unlock 1st EX Stage",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages","EX Stages"],
-		"requires": "|Progressive EX Stage Key:6| OR |Level 6 EX Stage Key|",
-		"place_item_category": ["Stages"]
+		"requires": "|Progressive EX Stage Key:6| OR |Level 6 EX Stage Key|"
 	},
 	{
 		"name": "Level 6 - Unlock 2nd EX Stage",
 		"region": "Royal Road",
 		"category": ["A6 - Level 6 Stages","EX Stages"],
-		"requires": "|Progressive EX Stage Key:6| OR |Level 6 EX Stage Key|",
-		"place_item_category": ["Stages"]
+		"requires": "|Progressive EX Stage Key:6| OR |Level 6 EX Stage Key|"
 	},
 	{
 		"name": "FiFi Stage 1 - Keychain in Grass",

--- a/manual_kirbytripledeluxe_seafo/hooks/Rules.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Rules.py
@@ -424,7 +424,7 @@ def can_use_crash(world: World, multiworld: MultiWorld, state: CollectionState, 
                 and (state.has("Lollipop Land Stage 3", player)
                      or (state.has("Grand Sun Stone", player, 2)
                          and (state.has("Progressive EX Stage Key", player, 3)
-                              or state.has("Level 3 EX Stage Key")
+                              or state.has("Level 3 EX Stage Key", player)
                               )
                          )
                      or state.has("Wild World Stage 3", player) or state.has("Wild World Stage 4", player)

--- a/manual_kirbytripledeluxe_seafo/hooks/Stage_Shuffle.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/Stage_Shuffle.py
@@ -1,0 +1,183 @@
+# Object classes from AP core, to represent an entire MultiWorld and this individual World that's part of it
+from worlds.AutoWorld import World
+from BaseClasses import MultiWorld, CollectionState, ItemClassification
+
+
+stage_order = []
+main_stage_order = []
+ex_stage_order = []
+boss_order = []
+
+
+def shuffle_stages_early(item_pool: list, world: World, multiworld: MultiWorld, player: int) -> list:
+    stage_shuffle = world.options.stage_shuffle
+    if stage_shuffle == 0:
+        # No stages are shuffled here, so we don't need any stage items.
+        stages = [i.name for i in item_pool
+                  if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
+                  or "Stage 4" in i.name or "Stage 5" in i.name or "Stage EX" in i.name]
+        for stages_to_remove in stages:
+            remove_stages = next(i for i in item_pool if i.name == stages_to_remove)
+            item_pool.remove(remove_stages)
+    elif stage_shuffle == 1:
+        # EX stages aren't shuffled here, so we don't need their items.
+        ex_stages = [i.name for i in item_pool if "Stage EX" in i.name]
+        for ex_stages_to_remove in ex_stages:
+            remove_ex_stages = next(i for i in item_pool if i.name == ex_stages_to_remove)
+            item_pool.remove(remove_ex_stages)
+
+        # Since only main stages are shuffled, we need to get one for the player to start with.
+        main_stages = [i for i in item_pool
+                       if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
+                       or "Stage 4" in i.name or "Stage 5" in i.name]
+        first_stage = world.random.choice(main_stages)
+        main_stage_order.append(first_stage)
+        multiworld.push_precollected(first_stage)
+        item_pool.remove(first_stage)
+    elif stage_shuffle == 2:
+        # Main stages aren't shuffled here, so we don't need their items.
+        main_stages = [i.name for i in item_pool
+                       if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
+                       or "Stage 4" in i.name or "Stage 5" in i.name]
+        for main_stages_to_remove in main_stages:
+            remove_main_stages = next(i for i in item_pool if i.name == main_stages_to_remove)
+            item_pool.remove(remove_main_stages)
+    elif stage_shuffle == 3:
+        # Since stages are shuffled, we need to get one for the player to start with.
+        # We're only checking for main stages here because EX stages should always be shuffled between themselves.
+        main_stages = [i for i in item_pool
+                       if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
+                       or "Stage 4" in i.name or "Stage 5" in i.name]
+        first_stage = world.random.choice(main_stages)
+        main_stage_order.append(first_stage)
+        multiworld.push_precollected(first_stage)
+        item_pool.remove(first_stage)
+    elif stage_shuffle == 4:
+        # Since stages are shuffled, we need to get one for the player to start with.
+        # In this case, we can start with any stage since they can each be in any position.
+        stages = [i for i in item_pool
+                  if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
+                  or "Stage 4" in i.name or "Stage 5" in i.name or "Stage EX" in i.name]
+        first_stage = world.random.choice(stages)
+        stage_order.append(first_stage)
+        multiworld.push_precollected(first_stage)
+        item_pool.remove(first_stage)
+    else:
+        raise Exception("Invalid value for option 'Stage Shuffle'. Please report this to the maintainer.")
+
+    return item_pool
+
+
+def shuffle_stages(world: World, multiworld: MultiWorld, player: int) -> list:
+    stage_shuffle = world.options.stage_shuffle
+
+    if stage_shuffle == 1 or stage_shuffle == 3:
+        main_stage_locs = [loc for loc in multiworld.get_locations(player)
+                           if "Unlock 1st Stage" in loc.name or "Unlock 2nd Stage" in loc.name
+                           or "Unlock 3rd" in loc.name or "Unlock 4th" in loc.name or "Unlock 5th" in loc.name]
+        main_stage_items = [i for i in multiworld.get_items() if i.player == player
+                            and ("Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
+                            or "Stage 4" in i.name or "Stage 5" in i.name)]
+        for main_stage in main_stage_locs:
+            # if len(main_stage_locs) == 0:
+            #     break
+            main_stage_item = world.random.choice(main_stage_items)
+            main_stage_order.append(main_stage_item)
+            main_stage.place_locked_item(main_stage_item)
+            multiworld.itempool.remove(main_stage_item)
+            main_stage_items.remove(main_stage_item)
+
+    if stage_shuffle == 2 or stage_shuffle == 3:
+        ex_stage_locs = [loc for loc in multiworld.get_locations(player)
+                         if "Unlock EX" in loc.name or "Unlock 1st EX" in loc.name or "Unlock 2nd EX" in loc.name]
+        ex_stage_items = [i for i in multiworld.get_items() if i.player == player
+                          and "Stage EX" in i.name]
+
+        for ex_stage in ex_stage_locs:
+            ex_stage_item = world.random.choice(ex_stage_items)
+            ex_stage_order.append(ex_stage_item)
+            ex_stage.place_locked_item(ex_stage_item)
+            multiworld.itempool.remove(ex_stage_item)
+            ex_stage_items.remove(ex_stage_item)
+
+    if stage_shuffle == 4:
+        stage_locs = [loc for loc in multiworld.get_locations(player)
+                      if "Level" in loc.name and "Boss" not in loc.name]
+        stage_items = [i for i in multiworld.get_items() if i.player == player
+                       and "Stage" in i.name and "Key" not in i.name]
+
+        for stage in stage_locs:
+            stage_item = world.random.choice(stage_items)
+            stage_order.append(stage_item)
+            stage.place_locked_item(stage_item)
+            multiworld.itempool.remove(stage_item)
+            stage_items.remove(stage_item)
+
+
+def shuffle_bosses(world: World, multiworld: MultiWorld, player: int) -> list:
+    boss_shuffle = world.options.boss_shuffle
+    if boss_shuffle == 0:
+        boss_stage_locs = [loc for loc in multiworld.get_locations(player)
+                           if "Level 1 Boss" in loc.name or "Level 2 Boss" in loc.name or "Level 3 Boss" in loc.name
+                           or "Level 4 Boss" in loc.name or "Level 5 Boss" in loc.name or "Level 6 Boss" in loc.name]
+        boss_stage_items = [i for i in multiworld.get_items() if i.player == player and "VS" in i.name]
+        for boss in boss_stage_items:
+            if len(boss_stage_locs) == 0:
+                break
+            boss_locations = boss_stage_locs.pop(0)
+            boss_locations.place_locked_item(boss)
+            multiworld.itempool.remove(boss)
+
+    if boss_shuffle == 1:
+        masked_dedede_loc = [loc for loc in multiworld.get_locations(player)
+                             if "Level 6 Boss" in loc.name]
+        masked_dedede_item = next(i for i in multiworld.get_items()
+                                  if i.player == player and i.name == "VS Masked Dedede")
+        place_dedede = masked_dedede_loc.pop()
+        place_dedede.place_locked_item(masked_dedede_item)
+        multiworld.itempool.remove(masked_dedede_item)
+
+        boss_stage_locs = [loc for loc in multiworld.get_locations(player)
+                           if "Level 1 Boss" in loc.name or "Level 2 Boss" in loc.name or "Level 3 Boss" in loc.name
+                           or "Level 4 Boss" in loc.name or "Level 5 Boss" in loc.name]
+        boss_stage_items = [i for i in multiworld.get_items()
+                            if i.player == player and "VS" in i.name and "VS Masked Dedede" not in i.name]
+        for boss_loc in boss_stage_locs:
+            boss_item = world.random.choice(boss_stage_items)
+            boss_order.append(boss_item)
+            boss_loc.place_locked_item(boss_item)
+            multiworld.itempool.remove(boss_item)
+            boss_stage_items.remove(boss_item)
+
+    if boss_shuffle == 2:
+        masked_dedede_loc = [loc for loc in multiworld.get_locations(player) if "Level 1 Boss" in loc.name]
+        masked_dedede_item = next(i for i in multiworld.get_items()
+                                  if i.player == player and i.name == "VS Masked Dedede")
+        place_dedede = masked_dedede_loc.pop()
+        boss_order.append(place_dedede)
+        place_dedede.place_locked_item(masked_dedede_item)
+        multiworld.itempool.remove(masked_dedede_item)
+
+        boss_stage_locs = [loc for loc in multiworld.get_locations(player)
+                           if "Level 2 Boss" in loc.name or "Level 3 Boss" in loc.name or "Level 4 Boss" in loc.name
+                           or "Level 5 Boss" in loc.name or "Level 6 Boss" in loc.name]
+        boss_stage_items = [i for i in multiworld.get_items()
+                            if i.player == player and "VS" in i.name and "VS Masked Dedede" not in i.name]
+        for boss_loc in boss_stage_locs:
+            boss_item = world.random.choice(boss_stage_items)
+            boss_order.append(boss_item)
+            boss_loc.place_locked_item(boss_item)
+            multiworld.itempool.remove(boss_item)
+            boss_stage_items.remove(boss_item)
+
+    if boss_shuffle == 3:
+        boss_stage_locs = [loc for loc in multiworld.get_locations(player)
+                           if "Level 1 Boss" in loc.name or "Level 2 Boss" in loc.name or "Level 3 Boss" in loc.name
+                           or "Level 4 Boss" in loc.name or "Level 5 Boss" in loc.name or "Level 6 Boss" in loc.name]
+        boss_stage_items = [i for i in multiworld.get_items() if i.player == player and "VS" in i.name]
+        for boss_loc in boss_stage_locs:
+            boss_item = world.random.choice(boss_stage_items)
+            boss_order.append(boss_item)
+            boss_loc.place_locked_item(boss_item)
+            multiworld.itempool.remove(boss_item)
+            boss_stage_items.remove(boss_item)

--- a/manual_kirbytripledeluxe_seafo/hooks/World.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/World.py
@@ -15,8 +15,8 @@ from ..Data import game_table, item_table, location_table, region_table
 # These helper methods allow you to determine if an option has been set, or what its value is, for any player in the multiworld
 from ..Helpers import is_option_enabled, get_option_value
 
-import re
-
+from .Stage_Shuffle import \
+    shuffle_stages_early, shuffle_stages, shuffle_bosses, stage_order, main_stage_order, ex_stage_order, boss_order
 
 ########################################################################################
 ## Order of method calls when the world generates:
@@ -226,9 +226,9 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
     # Because multiple copies of an item can exist, you need to add an item name
     # to the list multiple times if you want to remove multiple copies of it.
 
-    for itemName in itemNamesToRemove:
-        item = next(i for i in item_pool if i.name == itemName)
-        item_pool.remove(item)
+    # for itemName in itemNamesToRemove:
+    #     item = next(i for i in item_pool if i.name == itemName)
+    #     item_pool.remove(item)
 
     if world.options.ability_testing_room == 2:
         get_atr = [i.name for i in item_pool if i.name == "Copy Ability Testing Room"]
@@ -236,57 +236,7 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
             remove_atr = next(i for i in item_pool if i.name == atr)
             item_pool.remove(remove_atr)
 
-    stage_shuffle = world.options.stage_shuffle
-    if stage_shuffle == 0:
-        # No stages are shuffled here, so we don't need any stage items.
-        stages = [i.name for i in item_pool
-                  if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
-                  or "Stage 4" in i.name or "Stage 5" in i.name or "Stage EX" in i.name]
-        for stages_to_remove in stages:
-            remove_stages = next(i for i in item_pool if i.name == stages_to_remove)
-            item_pool.remove(remove_stages)
-    elif stage_shuffle == 1:
-        # EX stages aren't shuffled here, so we don't need their items.
-        ex_stages = [i.name for i in item_pool if "Stage EX" in i.name]
-        for ex_stages_to_remove in ex_stages:
-            remove_ex_stages = next(i for i in item_pool if i.name == ex_stages_to_remove)
-            item_pool.remove(remove_ex_stages)
-
-        # Since only main stages are shuffled, we need to get one for the player to start with.
-        main_stages = [i for i in item_pool
-                       if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
-                       or "Stage 4" in i.name or "Stage 5" in i.name]
-        first_stage = world.random.choice(main_stages)
-        multiworld.push_precollected(first_stage)
-        item_pool.remove(first_stage)
-    elif stage_shuffle == 2:
-        # Main stages aren't shuffled here, so we don't need their items.
-        main_stages = [i.name for i in item_pool
-                       if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
-                       or "Stage 4" in i.name or "Stage 5" in i.name]
-        for main_stages_to_remove in main_stages:
-            remove_main_stages = next(i for i in item_pool if i.name == main_stages_to_remove)
-            item_pool.remove(remove_main_stages)
-    elif stage_shuffle == 3:
-        # Since stages are shuffled, we need to get one for the player to start with.
-        # We're only checking for main stages here because EX stages should always be shuffled between themselves.
-        main_stages = [i for i in item_pool
-                       if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
-                       or "Stage 4" in i.name or "Stage 5" in i.name]
-        first_stage = world.random.choice(main_stages)
-        multiworld.push_precollected(first_stage)
-        item_pool.remove(first_stage)
-    elif stage_shuffle == 4:
-        # Since stages are shuffled, we need to get one for the player to start with.
-        # In this case, we can start with any stage since they can each be in any position.
-        stages = [i for i in item_pool
-                  if "Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
-                  or "Stage 4" in i.name or "Stage 5" in i.name or "Stage EX" in i.name]
-        first_stage = world.random.choice(stages)
-        multiworld.push_precollected(first_stage)
-        item_pool.remove(first_stage)
-    else:
-        raise Exception("Invalid value for option 'Stage Shuffle'. Please report this to the maintainer.")
+    shuffle_stages_early(item_pool, world, multiworld, player)
 
     if world.options.sun_stone_count.value < 100:
         unneeded_sun_stones = 100 - world.options.sun_stone_count.value
@@ -451,81 +401,13 @@ def after_create_item(item: ManualItem, world: World, multiworld: MultiWorld, pl
 
 # This method is run towards the end of pre-generation, before the place_item options have been handled and before AP generation occurs
 def before_generate_basic(world: World, multiworld: MultiWorld, player: int) -> list:
-    stage_shuffle = world.options.stage_shuffle
-    boss_shuffle = world.options.boss_shuffle
-    # Stage Shuffle 4 and Boss Shuffle 3 are the default behavior, so we don't need to place anything here.
-    # Stage Shuffle 0 doesn't need any items placed, so we also check for it.
-    if (stage_shuffle == 0 or stage_shuffle == 4) and boss_shuffle == 3:
+    shuffle_bosses(world, multiworld, player)
+
+    # We don't need to do anything if Stage Shuffle is disabled, so we quit out early.
+    if world.options.stage_shuffle == 0:
         return []
 
-    if stage_shuffle == 1 or stage_shuffle == 3:
-        main_stage_locs = [loc for loc in multiworld.get_locations(player)
-                           if "Unlock 1st Stage" in loc.name or "Unlock 2nd Stage" in loc.name
-                           or "Unlock 3rd" in loc.name or "Unlock 4th" in loc.name or "Unlock 5th" in loc.name]
-        main_stage_items = [i for i in multiworld.get_items() if i.player == player
-                            and ("Stage 1" in i.name or "Stage 2" in i.name or "Stage 3" in i.name
-                            or "Stage 4" in i.name or "Stage 5" in i.name)]
-        for main_stage in main_stage_items:
-            if len(main_stage_locs) == 0:
-                break
-
-            next_main_stage = world.random.choice(main_stage_locs)
-            next_main_stage.place_locked_item(main_stage)
-            multiworld.itempool.remove(main_stage)
-            main_stage_locs.remove(next_main_stage)
-
-    if stage_shuffle == 2 or stage_shuffle == 3:
-        ex_stage_locs = [loc for loc in multiworld.get_locations(player)
-                         if "Unlock EX" in loc.name or "Unlock 1st EX" in loc.name or "Unlock 2nd EX" in loc.name]
-        ex_stage_items = [i for i in multiworld.get_items() if i.player == player
-                          and "Stage EX" in i.name]
-
-        for ex_stage in ex_stage_items:
-            if len(ex_stage_locs) == 0:
-                break
-
-            next_ex_stage = world.random.choice(ex_stage_locs)
-            next_ex_stage.place_locked_item(ex_stage)
-            multiworld.itempool.remove(ex_stage)
-            ex_stage_locs.remove(next_ex_stage)
-
-    if boss_shuffle == 3:
-        return []
-
-    if boss_shuffle == 0:
-        boss_stage_locs = [loc for loc in multiworld.get_locations(player)
-                           if "Level 1 Boss" in loc.name or "Level 2 Boss" in loc.name or "Level 3 Boss" in loc.name
-                           or "Level 4 Boss" in loc.name or "Level 5 Boss" in loc.name or "Level 6 Boss" in loc.name]
-        boss_stage_items = [i for i in multiworld.get_items() if i.player == player and "VS" in i.name]
-        for boss in boss_stage_items:
-            if len(boss_stage_locs) == 0:
-                break
-
-            boss_locations = boss_stage_locs.pop(0)
-            boss_locations.place_locked_item(boss)
-            multiworld.itempool.remove(boss)
-
-    if boss_shuffle == 1:
-        masked_dedede_loc = [loc for loc in multiworld.get_locations(player) if "Level 6 Boss" in loc.name]
-        masked_dedede_item = [i for i in multiworld.get_items() if i.player == player and i.name == "VS Masked Dedede"]
-        for boss in masked_dedede_item:
-            if len(masked_dedede_loc) == 0:
-                break
-
-            place_dedede = masked_dedede_loc.pop()
-            place_dedede.place_locked_item(boss)
-            multiworld.itempool.remove(boss)
-
-    if boss_shuffle == 2:
-        masked_dedede_loc = [loc for loc in multiworld.get_locations(player) if "Level 1 Boss" in loc.name]
-        masked_dedede_item = [i for i in multiworld.get_items() if i.player == player and i.name == "VS Masked Dedede"]
-        for boss in masked_dedede_item:
-            if len(masked_dedede_loc) == 0:
-                break
-
-            place_dedede = masked_dedede_loc.pop()
-            place_dedede.place_locked_item(boss)
-            multiworld.itempool.remove(boss)
+    shuffle_stages(world, multiworld, player)
 
 
 # This method is run at the very end of pre-generation, once the place_item options have been handled and before AP generation occurs
@@ -566,4 +448,80 @@ def before_extend_hint_information(hint_data: dict[int, dict[int, str]], world: 
 
 
 def after_extend_hint_information(hint_data: dict[int, dict[int, str]], world: World, multiworld: MultiWorld, player: int) -> None:
+    # In order to figure out hint information, we primarily need to check which items were placed on which locations.
+    # We then add the information to any of the corresponding locations.
+    # Not sure whether I'll use category or name lookup here, since both should work fine.
+    #
+    # Stage Shuffle has an additional caveat where we need to check which stage is in the player's starting inventory.
+    # This caveat does not apply to shuffling EX stages among themselves, which may cause 3 and 4 to need to be handled
+    # differently in some way.
+    #
+    # Boss Shuffle needs to filter out the Sun Stone requirement from the boss's location.
+    # Since this should always be clear to the player, we want to cut it down to only the level that the boss is in.
+    # This also creates some parity with how Stage Shuffle will be handled.
+    #
+    stage_shuffle = world.options.stage_shuffle
+    boss_shuffle = world.options.boss_shuffle
+    if stage_shuffle > 0 or boss_shuffle > 0:
+        hint_data.update({player: {}})
+    # Stage Shuffle first checks for if it has been enabled.
+    # Next, it needs to check for the specific value.
+    # 1 means only main stages are shuffled, 2 means only EX stages are shuffled, and 3 and 4 mean both are shuffled.
+    # We need one statement for main stages and one statement for EX stages, but shuffling both is more complicated.
+    # Either we can add a third statement that handles them individually, or we can just use the first two statements.
+    if stage_shuffle > 0:
+        if stage_shuffle == 1 or stage_shuffle == 3:
+            # TODO: Rewrite this to fetch the location names instead.
+            main_stage_locs = ["Level 1 - 1st Stage", "Level 1 - 2nd Stage",
+                               "Level 1 - 3rd Stage", "Level 1 - 4th Stage",
+                               "Level 2 - 1st Stage", "Level 2 - 2nd Stage",
+                               "Level 2 - 3rd Stage", "Level 2 - 4th Stage",
+                               "Level 3 - 1st Stage", "Level 3 - 2nd Stage",
+                               "Level 3 - 3rd Stage", "Level 3 - 4th Stage", "Level 3 - 5th Stage",
+                               "Level 4 - 1st Stage", "Level 4 - 2nd Stage",
+                               "Level 4 - 3rd Stage", "Level 4 - 4th Stage", "Level 4 - 5th Stage",
+                               "Level 5 - 1st Stage", "Level 5 - 2nd Stage",
+                               "Level 5 - 3rd Stage", "Level 5 - 4th Stage", "Level 5 - 5th Stage",
+                               "Level 6 - 1st Stage", "Level 6 - 2nd Stage",
+                               "Level 6 - 3rd Stage", "Level 6 - 4th Stage", "Level 6 - 5th Stage"]
+            main_stage_items = main_stage_order
+            iter(main_stage_items)
+
+
+        # for location in multiworld.get_locations(player):
+        #     if not location.address:
+        #         continue
+        #     if stage_shuffle == 1 or stage_shuffle == 3:
+        #         # TODO: Rewrite this to fetch the location names instead.
+        #         stage_locs = ["Level 1 - 1st Stage", "Level 1 - 2nd Stage",
+        #                       "Level 1 - 3rd Stage", "Level 1 - 4th Stage",
+        #                       "Level 2 - 1st Stage", "Level 2 - 2nd Stage",
+        #                       "Level 2 - 3rd Stage", "Level 2 - 4th Stage",
+        #                       "Level 3 - 1st Stage", "Level 3 - 2nd Stage",
+        #                       "Level 3 - 3rd Stage", "Level 3 - 4th Stage", "Level 3 - 5th Stage",
+        #                       "Level 4 - 1st Stage", "Level 4 - 2nd Stage",
+        #                       "Level 4 - 3rd Stage", "Level 4 - 4th Stage", "Level 4 - 5th Stage",
+        #                       "Level 5 - 1st Stage", "Level 5 - 2nd Stage",
+        #                       "Level 5 - 3rd Stage", "Level 5 - 4th Stage", "Level 5 - 5th Stage",
+        #                       "Level 6 - 1st Stage", "Level 6 - 2nd Stage",
+        #                       "Level 6 - 3rd Stage", "Level 6 - 4th Stage", "Level 6 - 5th Stage"]
+        #         # shuffled_main_stages, stage_locations = zip(*stage_locs, main_stage_order)
+        #         next_main_stage_item = iter(main_stage_order)
+        #         next_main_stage_loc = iter(stage_locs)
+        #         for _ in main_stage_order:
+
+                    # next_stage_loc = (loc.name for loc in multiworld.get_locations(player)
+                    #                   if next(next_main_stage_item) in loc.category)
+                    # print(next_stage_loc)
+                    # hint_data[player][world.multiworld.get_location(f"{next_stage_loc}", player).address] =\
+                    #     next(next_main_stage_loc)
+    # Boss Shuffle is much simpler to handle than Stage Shuffle.
+    # First we check if it has been enabled.
+    # Then we check whether the value is 1 or higher.
+    # 1 has a unique case where it needs to add hint information for everything except Masked Dedede.
+    # Meanwhile, 2 and 3 always need to give the player information about all 6 bosses.
+    if boss_shuffle > 0:
+        for location in multiworld.get_locations(player):
+            if not location.address:
+                continue
     pass

--- a/manual_kirbytripledeluxe_seafo/hooks/World.py
+++ b/manual_kirbytripledeluxe_seafo/hooks/World.py
@@ -69,39 +69,38 @@ def before_create_regions(world: World, multiworld: MultiWorld, player: int):
             location_total += 10
         if world.options.ability_testing_room == 1:
             item_total += 1
-        #
-        # Special handling for if the number of locations were to exceed the number of items.
-        # This isn't relevant for KTD due to the way its options work out, but was kept here for future reference.
-        #
-        # extra_locations = location_total - item_total
-        # if extra_locations > 100:
-        #     sun_stone_locations = 100
-        # else:
-        #     sun_stone_locations = extra_locations
-        #
-        # This line is only here due to the above lines being unnecessary:
-        sun_stone_locations = location_total - item_total
-
-        world.options.sun_stone_count.value = sun_stone_locations
+        extra_locations = location_total - item_total
+        # Ensuring that the number of Sun Stones added to the pool isn't higher than the number defined by the option.
+        if extra_locations >= world.options.sun_stone_count.value:
+            pass
+        else:
+            print("Not enough locations for all Sun Stones to be placed. Removing excess Sun Stones.")
+            world.options.sun_stone_count.value = extra_locations
 
     sun_stones = world.options.sun_stone_count.value
 
     if world.options.level_1_boss_sun_stones > sun_stones:
+        print("Not enough Sun Stones to match Level 1 Boss requirement. Lowering requirement to match number created.")
         world.options.level_1_boss_sun_stones.value = sun_stones
 
     if world.options.level_2_boss_sun_stones > sun_stones:
+        print("Not enough Sun Stones to match Level 2 Boss requirement. Lowering requirement to match number created.")
         world.options.level_2_boss_sun_stones.value = sun_stones
 
     if world.options.level_3_boss_sun_stones > sun_stones:
+        print("Not enough Sun Stones to match Level 3 Boss requirement. Lowering requirement to match number created.")
         world.options.level_3_boss_sun_stones.value = sun_stones
 
     if world.options.level_4_boss_sun_stones > sun_stones:
+        print("Not enough Sun Stones to match Level 4 Boss requirement. Lowering requirement to match number created.")
         world.options.level_4_boss_sun_stones.value = sun_stones
 
     if world.options.level_5_boss_sun_stones > sun_stones:
+        print("Not enough Sun Stones to match Level 5 Boss requirement. Lowering requirement to match number created.")
         world.options.level_5_boss_sun_stones.value = sun_stones
 
     if world.options.level_6_boss_sun_stones > sun_stones:
+        print("Not enough Sun Stones to match Level 6 Boss requirement. Lowering requirement to match number created.")
         world.options.level_6_boss_sun_stones.value = sun_stones
 
 
@@ -345,11 +344,10 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
         item_total += world.options.sun_stone_count.value
         open_locations = location_total - item_total
         if open_locations < 36:
+            print("Not enough locations to place all Rare Keychains. Removing the excess.")
             # We remove the Queen Sectonia Keychain first because it doesn't have an equivalent location.
-            sectonia_keychain = [i for i in item_pool if i.name == "Queen Sectonia Keychain"]
-            for sectonia in sectonia_keychain:
-                remove_sectonia = next(i for i in item_pool if i.name == sectonia)
-                item_pool.remove(remove_sectonia)
+            sectonia_keychain = next(i for i in item_pool if i.name == "Queen Sectonia Keychain")
+            item_pool.remove(sectonia_keychain)
             # If we still don't have enough room, we need to remove more Rare Keychains at random to make up for it.
             if open_locations < 35:
                 rare_keychains = [i for i in item_pool if " Keychain" in i.name]


### PR DESCRIPTION
Adds extra hint information to KTD's Stage Shuffle and Boss Shuffle options, allowing hinted items and locations to tell the player which Level they're in. In order to support this, full shuffling for both options was moved from being handled by Manual's core options to my own hooks, and the corresponding `place_item_category` statements were removed due to them now being entirely redundant.